### PR TITLE
Prestige projection module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,7 @@
+# CereBro Context
+
+## MCOC Prestige Projection
+
+MCOC Prestige Projection is the domain rule set for turning champion prestige endpoints, rarity, rank, signature level, and ascension into game-display prestige values and chart-ready prestige curves.
+
+It owns max signature levels, 7-star ascension scaling, game-display rounding, and generated prestige points used by roster insights, Champion Details, and roster edit previews.

--- a/package.json
+++ b/package.json
@@ -88,5 +88,5 @@
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },
-  "packageManager": "pnpm@10.22.0+sha512.bf049efe995b28f527fd2b41ae0474ce29186f7edcb3bf545087bd61fbbebb2bf75362d1307fda09c2d288e1e499787ac12d4fcb617a974718a6051f2eee741c"
+  "packageManager": "pnpm@10.33.3+sha512.a19744364a7e248b92657a4ca5973f9354d21caf982579674b1c539f32c7420c47138ad8b1254df07aba9bc782d9b3029e3db34d5dbff974326eb74dac8ff489"
 }

--- a/web/src/app/api/profile/champion-prestige/route.ts
+++ b/web/src/app/api/profile/champion-prestige/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import logger from "@/lib/logger";
 import { withRouteContext } from "@/lib/with-request-context";
+import { expandMcocPrestigeCurve } from "@/lib/mcoc-prestige";
 
 const querySchema = z.object({
   championId: z.coerce.number(),
@@ -28,31 +29,19 @@ export const GET = withRouteContext(async (req: Request) => {
         rank,
       },
       orderBy: { sig: 'asc' },
-      select: { sig: true, prestige: true },
+      select: { championId: true, rarity: true, rank: true, sig: true, prestige: true },
     });
 
     if (prestige.length === 0) {
       return NextResponse.json({ error: "Prestige data not found" }, { status: 404 });
     }
 
-    // Interpolate missing sig levels between stored data points
-    const interpolated: { sig: number; prestige: number }[] = [];
-    for (let i = 0; i < prestige.length; i++) {
-      interpolated.push(prestige[i]);
-      if (i < prestige.length - 1) {
-        const curr = prestige[i];
-        const next = prestige[i + 1];
-        for (let sig = curr.sig + 1; sig < next.sig; sig++) {
-          const t = (sig - curr.sig) / (next.sig - curr.sig);
-          interpolated.push({
-            sig,
-            prestige: Math.round((curr.prestige + t * (next.prestige - curr.prestige)) / 10) * 10,
-          });
-        }
-      }
-    }
-
-    return NextResponse.json(interpolated);
+    return NextResponse.json(
+      expandMcocPrestigeCurve({
+        prestigeData: prestige,
+        stat: { rarity, rank, prestige: prestige.find(row => row.sig === 0)?.prestige ?? null },
+      })
+    );
   } catch (error) {
     logger.error({ error, championId }, "Error fetching prestige data");
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/web/src/app/api/profile/roster/add/route.ts
+++ b/web/src/app/api/profile/roster/add/route.ts
@@ -19,11 +19,12 @@ const addSchema = z.object({
   ascensionLevel: z.number().int().min(0).max(5).optional().default(0),
   targetPlayerId: z.string().optional(),
 }).superRefine((data, ctx) => {
-  if (data.ascensionLevel > maxAscensionLevelForRarity(data.stars)) {
+  const maxAscensionLevel = maxAscensionLevelForRarity(data.stars);
+  if (data.ascensionLevel > maxAscensionLevel) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["ascensionLevel"],
-      message: "Ascension level is only allowed for 7-star champions.",
+      message: `Ascension level exceeds the maximum allowed for this rarity (${maxAscensionLevel}).`,
     });
   }
 });

--- a/web/src/app/api/profile/roster/add/route.ts
+++ b/web/src/app/api/profile/roster/add/route.ts
@@ -7,6 +7,7 @@ import logger from "@/lib/logger";
 import { clearCache } from "@/lib/cache";
 import { Prisma } from "@prisma/client";
 import { withRouteContext } from "@/lib/with-request-context";
+import { maxAscensionLevelForRarity } from "@/lib/mcoc-prestige";
 
 const addSchema = z.object({
   championId: z.number().int().min(1),
@@ -17,6 +18,14 @@ const addSchema = z.object({
   isAscended: z.boolean().optional().default(false),
   ascensionLevel: z.number().int().min(0).max(5).optional().default(0),
   targetPlayerId: z.string().optional(),
+}).superRefine((data, ctx) => {
+  if (data.ascensionLevel > maxAscensionLevelForRarity(data.stars)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["ascensionLevel"],
+      message: "Ascension level is only allowed for 7-star champions.",
+    });
+  }
 });
 
 async function addChampionUpsert(playerId: string, data: z.infer<typeof addSchema>) {

--- a/web/src/app/api/profile/roster/add/route.ts
+++ b/web/src/app/api/profile/roster/add/route.ts
@@ -15,7 +15,7 @@ const addSchema = z.object({
   sigLevel: z.number().int().min(0).max(200).optional().default(0),
   isAwakened: z.boolean().optional().default(false),
   isAscended: z.boolean().optional().default(false),
-  ascensionLevel: z.number().int().min(0).max(2).optional().default(0),
+  ascensionLevel: z.number().int().min(0).max(5).optional().default(0),
   targetPlayerId: z.string().optional(),
 });
 

--- a/web/src/app/api/profile/roster/manage/route.ts
+++ b/web/src/app/api/profile/roster/manage/route.ts
@@ -12,7 +12,7 @@ const updateSchema = z.object({
   rank: z.number().min(1).max(10).optional(),
   isAwakened: z.boolean().optional(),
   isAscended: z.boolean().optional(),
-  ascensionLevel: z.number().min(0).max(2).optional(),
+  ascensionLevel: z.number().min(0).max(5).optional(),
   sigLevel: z.number().min(0).max(200).optional(),
 });
 

--- a/web/src/app/api/profile/roster/manage/route.ts
+++ b/web/src/app/api/profile/roster/manage/route.ts
@@ -63,10 +63,23 @@ export const PUT = withRouteContext(async (req: Request) => {
       );
     }
 
-    const normalizedAscensionLevel =
-      ascensionLevel === undefined
-        ? undefined
-        : clampAscensionLevelForRarity(ascensionLevel, rosterEntry.stars);
+    if (
+      ascensionLevel !== undefined &&
+      ascensionLevel !== clampAscensionLevelForRarity(ascensionLevel, rosterEntry.stars)
+    ) {
+      return NextResponse.json(
+        {
+          error: "Invalid data",
+          details: [
+            {
+              path: ["ascensionLevel"],
+              message: "Ascension level exceeds the maximum allowed for this rarity.",
+            },
+          ],
+        },
+        { status: 400 }
+      );
+    }
 
     const updatedRoster = await prisma.roster.update({
       where: { id },
@@ -74,7 +87,7 @@ export const PUT = withRouteContext(async (req: Request) => {
         rank,
         isAwakened,
         isAscended,
-        ascensionLevel: normalizedAscensionLevel,
+        ascensionLevel,
         sigLevel,
       },
       include: {

--- a/web/src/app/api/profile/roster/manage/route.ts
+++ b/web/src/app/api/profile/roster/manage/route.ts
@@ -6,6 +6,7 @@ import { getUserPlayerWithAlliance } from "@/lib/auth-helpers";
 import logger from "@/lib/logger";
 import { clearCache } from "@/lib/cache";
 import { withRouteContext } from "@/lib/with-request-context";
+import { clampAscensionLevelForRarity } from "@/lib/mcoc-prestige";
 
 const updateSchema = z.object({
   id: z.string(),
@@ -62,13 +63,18 @@ export const PUT = withRouteContext(async (req: Request) => {
       );
     }
 
+    const normalizedAscensionLevel =
+      ascensionLevel === undefined
+        ? undefined
+        : clampAscensionLevelForRarity(ascensionLevel, rosterEntry.stars);
+
     const updatedRoster = await prisma.roster.update({
       where: { id },
       data: {
         rank,
         isAwakened,
         isAscended,
-        ascensionLevel,
+        ascensionLevel: normalizedAscensionLevel,
         sigLevel,
       },
       include: {

--- a/web/src/app/champions/[slug]/champion-details-client.tsx
+++ b/web/src/app/champions/[slug]/champion-details-client.tsx
@@ -16,7 +16,7 @@ import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { getChampionClassColors } from "@/lib/championClassHelper"
 import { getChampionImageUrlOrPlaceholder } from "@/lib/championHelper"
-import { calculateMcocPrestige, maxSigForRarity } from "@/lib/mcoc-prestige"
+import { applyAscensionToStatValue, maxSigForRarity, projectMcocPrestige } from "@/lib/mcoc-prestige"
 import { cn } from "@/lib/utils"
 import { ChampionImages } from "@/types/champion"
 
@@ -193,8 +193,12 @@ export function ChampionDetailsClient({
   const bioTexts = textGroups.bio ?? []
   const selectedRarityLabel = selectedStat?.rarityLabel ?? (selectedRarity ? `${selectedRarity}-star` : "No stats")
   const selectedCurves = champion.abilityCurves.filter(curve => (curve.maxSig ?? 200) === currentMaxSig)
-  const selectedBasePrestige = calculateMcocPrestige(champion.prestigeData, selectedStat, sigLevel)
-  const selectedPrestige = applyAscensionToPrestige(selectedBasePrestige, selectedStat?.rarity, ascensionLevel)
+  const selectedPrestige = projectMcocPrestige({
+    prestigeData: champion.prestigeData,
+    stat: selectedStat,
+    sigLevel,
+    ascensionLevel,
+  })
   const displayStat = useMemo(
     () => applyAscensionToStat(selectedStat, ascensionLevel),
     [selectedStat, ascensionLevel]
@@ -205,8 +209,8 @@ export function ChampionDetailsClient({
   const displayMaxStats = useMemo(
     () => ({
       ...maxStats,
-      health: applyAscensionToNumber(maxStats.health, selectedStat?.rarity, ascensionLevel),
-      attack: applyAscensionToNumber(maxStats.attack, selectedStat?.rarity, ascensionLevel),
+      health: applyAscensionToStatValue(maxStats.health, selectedStat?.rarity, ascensionLevel),
+      attack: applyAscensionToStatValue(maxStats.attack, selectedStat?.rarity, ascensionLevel),
     }),
     [maxStats, selectedStat?.rarity, ascensionLevel]
   )
@@ -337,7 +341,7 @@ export function ChampionDetailsClient({
                         max={currentMaxSig}
                         step={1}
                         value={[sigLevel]}
-                        onValueChange={val => setSigLevel(val[0])}
+                        onValueChange={(val: number[]) => setSigLevel(val[0])}
                         className="flex-1"
                       />
                       <span className="w-12 rounded border border-slate-700 bg-slate-900 px-2 py-1 text-center font-mono text-sm text-slate-100">
@@ -451,27 +455,12 @@ function HeroMetric({ icon, label, value, accent }: { icon: ReactNode; label: st
   )
 }
 
-function ascensionMultiplier(rarity: number | null | undefined, ascensionLevel: number) {
-  return rarity === 7 && ascensionLevel > 0 ? Math.pow(1.08, ascensionLevel) : 1
-}
-
-function applyAscensionToNumber(value: number | null | undefined, rarity: number | null | undefined, ascensionLevel: number) {
-  if (value == null) return null
-  return Math.round(value * ascensionMultiplier(rarity, ascensionLevel))
-}
-
-function applyAscensionToPrestige(value: number | null | undefined, rarity: number | null | undefined, ascensionLevel: number) {
-  if (value == null) return null
-  const scaled = value * ascensionMultiplier(rarity, ascensionLevel)
-  return Math.round(scaled / 10) * 10
-}
-
 function applyAscensionToStat(stat: ChampionStatRow | undefined, ascensionLevel: number): ChampionStatRow | undefined {
   if (!stat) return stat
   return {
     ...stat,
-    health: applyAscensionToNumber(stat.health, stat.rarity, ascensionLevel),
-    attack: applyAscensionToNumber(stat.attack, stat.rarity, ascensionLevel),
+    health: applyAscensionToStatValue(stat.health, stat.rarity, ascensionLevel),
+    attack: applyAscensionToStatValue(stat.attack, stat.rarity, ascensionLevel),
   }
 }
 

--- a/web/src/app/profile/roster/components/modals/add-champion-modal.tsx
+++ b/web/src/app/profile/roster/components/modals/add-champion-modal.tsx
@@ -8,6 +8,7 @@ import { getChampionImageUrl, getMaxRank } from "@/lib/championHelper";
 import { getChampionClassColors } from "@/lib/championClassHelper";
 import { cn } from "@/lib/utils";
 import Image from "next/image";
+import { maxSigForRarity } from "@/lib/mcoc-prestige";
 
 interface NewChampionFormData {
     championId: number | null;
@@ -34,7 +35,7 @@ export function AddChampionModal({ open, onOpenChange, allChampions, onAdd, newC
     const heroUrl = selectedChampion ? getChampionImageUrl(selectedChampion.images, 'full', 'hero') : null;
 
     const maxRank = getMaxRank(newChampion.stars);
-    const maxSig = newChampion.stars >= 5 ? 200 : 99;
+    const maxSig = maxSigForRarity(newChampion.stars);
     const sigQuickValues = newChampion.stars >= 5 ? [0, 50, 100, 150, 200] : [0, 25, 50, 75, 99];
 
     const setSig = (val: number) => {
@@ -45,7 +46,7 @@ export function AddChampionModal({ open, onOpenChange, allChampions, onAdd, newC
     const handleStarChange = (newStars: number) => {
         const newMaxRank = getMaxRank(newStars);
         const clampedRank = Math.min(newChampion.rank, newMaxRank);
-        const newMaxSig = newStars >= 5 ? 200 : 99;
+        const newMaxSig = maxSigForRarity(newStars);
         const clampedSig = Math.min(newChampion.sigLevel, newMaxSig);
         onNewChampionChange({...newChampion, stars: newStars, rank: clampedRank, sigLevel: clampedSig});
     };

--- a/web/src/app/profile/roster/components/modals/edit-champion-modal.tsx
+++ b/web/src/app/profile/roster/components/modals/edit-champion-modal.tsx
@@ -9,6 +9,7 @@ import { getChampionImageUrl, getMaxRank } from '@/lib/championHelper';
 import { getChampionClassColors } from "@/lib/championClassHelper";
 import { cn } from "@/lib/utils";
 import { ProfileRosterEntry, PrestigePoint } from "../../types";
+import { maxSigForRarity, projectMcocPrestigeFromCurve } from "@/lib/mcoc-prestige";
 
 interface EditChampionModalProps {
     item: ProfileRosterEntry | null;
@@ -17,26 +18,6 @@ interface EditChampionModalProps {
     onUpdate: (data: Partial<ProfileRosterEntry> & { id: string }) => void;
     onDelete: (id: string) => void;
     onItemChange: (item: ProfileRosterEntry) => void;
-}
-
-function computePrestige(curve: PrestigePoint[], sig: number, stars: number, ascensionLevel: number): number {
-    if (!curve.length) return 0;
-    const point = curve.find(p => p.sig === sig);
-    let base = point?.prestige ?? 0;
-    if (!base) {
-        const lower = [...curve].filter(p => p.sig <= sig).pop();
-        const upper = curve.find(p => p.sig > sig);
-        if (lower && upper) {
-            const t = (sig - lower.sig) / (upper.sig - lower.sig);
-            base = Math.round((lower.prestige + t * (upper.prestige - lower.prestige)) / 10) * 10;
-        } else {
-            base = lower?.prestige ?? upper?.prestige ?? 0;
-        }
-    }
-    if (base > 0 && stars === 7 && ascensionLevel > 0) {
-        base = Math.round((base * Math.pow(1.08, ascensionLevel)) / 10) * 10;
-    }
-    return base;
 }
 
 export function EditChampionModal({ item, prestige: initialPrestige, onClose, onUpdate, onDelete, onItemChange }: EditChampionModalProps) {
@@ -79,7 +60,12 @@ export function EditChampionModal({ item, prestige: initialPrestige, onClose, on
         if (!item) return;
         const curve = prestigeCurves.get(item.rank);
         if (!curve) { setLivePrestige(undefined); return; }
-        const computed = computePrestige(curve, item.sigLevel || 0, item.stars, item.ascensionLevel || 0);
+        const computed = projectMcocPrestigeFromCurve({
+            curve,
+            sigLevel: item.sigLevel || 0,
+            rarity: item.stars,
+            ascensionLevel: item.ascensionLevel || 0,
+        });
         setLivePrestige(computed || undefined);
     }, [item, prestigeCurves]);
 
@@ -89,7 +75,7 @@ export function EditChampionModal({ item, prestige: initialPrestige, onClose, on
 
     const classColors = getChampionClassColors(item.champion.class);
     const maxRank = getMaxRank(item.stars);
-    const maxSig = item.stars >= 5 ? 200 : 99;
+    const maxSig = maxSigForRarity(item.stars);
     const sigQuickValues = item.stars >= 5 ? [0, 50, 100, 150, 200] : [0, 25, 50, 75, 99];
     const heroUrl = getChampionImageUrl(item.champion.images, 'full', 'hero');
 

--- a/web/src/app/profile/roster/components/modals/edit-champion-modal.tsx
+++ b/web/src/app/profile/roster/components/modals/edit-champion-modal.tsx
@@ -76,7 +76,9 @@ export function EditChampionModal({ item, prestige: initialPrestige, onClose, on
     const classColors = getChampionClassColors(item.champion.class);
     const maxRank = getMaxRank(item.stars);
     const maxSig = maxSigForRarity(item.stars);
-    const sigQuickValues = item.stars >= 5 ? [0, 50, 100, 150, 200] : [0, 25, 50, 75, 99];
+    const sigQuickValues = Array.from(
+        new Set([0, 0.25, 0.5, 0.75, 1].map(value => Math.max(0, Math.min(maxSig, Math.round(maxSig * value)))))
+    ).sort((a, b) => a - b);
     const heroUrl = getChampionImageUrl(item.champion.images, 'full', 'hero');
 
     const setSig = (val: number) => {

--- a/web/src/lib/mcoc-prestige.test.ts
+++ b/web/src/lib/mcoc-prestige.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import {
+  expandMcocPrestigeCurve,
+  maxAscensionLevelForRarity,
+  maxSigForRarity,
+  projectMcocPrestige,
+  projectMcocPrestigeFromCurve,
+} from "./mcoc-prestige";
+
+const sevenStarRankThree = {
+  rarity: 7,
+  rank: 3,
+  prestige: 22000,
+};
+
+const endpoints = [
+  { rarity: 7, rank: 3, sig: 0, prestige: 22000 },
+  { rarity: 7, rank: 3, sig: 1, prestige: 22100 },
+  { rarity: 7, rank: 3, sig: 200, prestige: 26000 },
+];
+
+describe("MCOC Prestige Projection", () => {
+  it("owns max signature and ascension caps by rarity", () => {
+    expect(maxSigForRarity(4)).toBe(99);
+    expect(maxSigForRarity(5)).toBe(200);
+    expect(maxSigForRarity(7)).toBe(200);
+
+    expect(maxAscensionLevelForRarity(6)).toBe(0);
+    expect(maxAscensionLevelForRarity(7)).toBe(5);
+  });
+
+  it("projects game-display prestige with 7-star ascension scaling", () => {
+    expect(projectMcocPrestige({
+      prestigeData: endpoints,
+      stat: sevenStarRankThree,
+      sigLevel: 0,
+      ascensionLevel: 0,
+    })).toBe(22000);
+
+    expect(projectMcocPrestige({
+      prestigeData: endpoints,
+      stat: sevenStarRankThree,
+      sigLevel: 0,
+      ascensionLevel: 5,
+    })).toBe(32330);
+  });
+
+  it("expands chart curves through the same projection rules", () => {
+    const curve = expandMcocPrestigeCurve({
+      prestigeData: endpoints,
+      stat: sevenStarRankThree,
+    });
+
+    expect(curve).toHaveLength(201);
+    expect(curve[0]).toEqual({ sig: 0, prestige: 22000 });
+    expect(curve[1]).toEqual({ sig: 1, prestige: 22100 });
+    expect(curve[200]).toEqual({ sig: 200, prestige: 26000 });
+    expect(projectMcocPrestigeFromCurve({
+      curve,
+      sigLevel: 200,
+      rarity: 7,
+      ascensionLevel: 5,
+    })).toBe(38200);
+  });
+});

--- a/web/src/lib/mcoc-prestige.ts
+++ b/web/src/lib/mcoc-prestige.ts
@@ -106,26 +106,59 @@ export function projectMcocPrestige({
   return applyAscensionToPrestige(basePrestige, stat?.rarity, ascensionLevel);
 }
 
+/**
+ * Expands an ascension-free prestige curve. Returned points are base
+ * ascensionLevel=0 values; apply ascension with projectMcocPrestigeFromCurve.
+ */
 export function expandMcocPrestigeCurve({
   prestigeData,
   stat,
-  ascensionLevel = 0,
 }: {
   prestigeData: McocPrestigeEndpoint[];
   stat: McocPrestigeStat;
-  ascensionLevel?: number;
 }): McocPrestigePoint[] {
   const maxSig = maxSigForRarity(stat.rarity);
   const points: McocPrestigePoint[] = [];
+  const rows = prestigeData.filter(row => row.rarity === stat.rarity && row.rank === stat.rank);
+  const prestige0 = rows.find(row => row.sig === 0)?.prestige ?? stat.prestige ?? null;
+  const prestige1 = rows.find(row => row.sig === 1)?.prestige ?? null;
+  const prestigeMax = rows.find(row => row.sig === maxSig)?.prestige ?? null;
+  const curve = stat.rarity
+    ? MCOC_PRESTIGE_RARITY_CURVES[stat.rarity as keyof typeof MCOC_PRESTIGE_RARITY_CURVES]
+    : undefined;
+  const prestigeBySig = new Map<number, number>();
+
+  if (prestige0 == null) return points;
 
   for (let sig = 0; sig <= maxSig; sig++) {
-    const prestige = projectMcocPrestige({ prestigeData, stat, sigLevel: sig, ascensionLevel });
+    if (sig === 0) {
+      prestigeBySig.set(sig, prestige0);
+    } else if (prestige1 == null) {
+      prestigeBySig.set(sig, prestige0);
+    } else if (sig === 1) {
+      prestigeBySig.set(sig, prestige1);
+    } else if (prestigeMax == null || prestigeMax <= prestige1) {
+      prestigeBySig.set(sig, prestige1);
+    } else if (sig >= maxSig) {
+      prestigeBySig.set(sig, prestigeMax);
+    } else {
+      const factor = curve?.[sig - 1];
+      prestigeBySig.set(sig, factor == null ? prestige1 : Math.round(prestige1 + (prestigeMax - prestige1) * factor));
+    }
+  }
+
+  for (let sig = 0; sig <= maxSig; sig++) {
+    const prestige = prestigeBySig.get(sig);
     if (prestige != null) points.push({ sig, prestige });
   }
 
   return points;
 }
 
+/**
+ * Projects prestige from an ascension-free curve. The curve must contain base
+ * prestige values only; ascension is applied exactly once here.
+ */
 export function projectMcocPrestigeFromCurve({
   curve,
   sigLevel,

--- a/web/src/lib/mcoc-prestige.ts
+++ b/web/src/lib/mcoc-prestige.ts
@@ -13,8 +13,54 @@ export type McocPrestigeStat = {
   prestige: number | null | undefined;
 };
 
+export type McocPrestigePoint = {
+  sig: number;
+  prestige: number;
+};
+
 export function maxSigForRarity(rarity: number | null | undefined) {
   return rarity && rarity < 5 ? 99 : 200;
+}
+
+export function maxAscensionLevelForRarity(rarity: number | null | undefined) {
+  return rarity === 7 ? 5 : 0;
+}
+
+export function clampSigForRarity(sigLevel: number, rarity: number | null | undefined) {
+  const maxSig = maxSigForRarity(rarity);
+  return Math.max(0, Math.min(maxSig, Math.round(sigLevel)));
+}
+
+export function clampAscensionLevelForRarity(ascensionLevel: number, rarity: number | null | undefined) {
+  const maxAscension = maxAscensionLevelForRarity(rarity);
+  return Math.max(0, Math.min(maxAscension, Math.round(ascensionLevel)));
+}
+
+export function roundPrestigeToGameDisplay(value: number) {
+  return value > 0 ? Math.round(value / 10) * 10 : 0;
+}
+
+export function ascensionMultiplierForRarity(rarity: number | null | undefined, ascensionLevel: number) {
+  const clampedAscension = clampAscensionLevelForRarity(ascensionLevel, rarity);
+  return rarity === 7 && clampedAscension > 0 ? Math.pow(1.08, clampedAscension) : 1;
+}
+
+export function applyAscensionToPrestige(
+  value: number | null | undefined,
+  rarity: number | null | undefined,
+  ascensionLevel: number
+) {
+  if (value == null) return null;
+  return roundPrestigeToGameDisplay(value * ascensionMultiplierForRarity(rarity, ascensionLevel));
+}
+
+export function applyAscensionToStatValue(
+  value: number | null | undefined,
+  rarity: number | null | undefined,
+  ascensionLevel: number
+) {
+  if (value == null) return null;
+  return Math.round(value * ascensionMultiplierForRarity(rarity, ascensionLevel));
 }
 
 export function calculateMcocPrestige(
@@ -43,4 +89,56 @@ export function calculateMcocPrestige(
   if (factor == null) return prestige1;
 
   return Math.round(prestige1 + (prestigeMax - prestige1) * factor);
+}
+
+export function projectMcocPrestige({
+  prestigeData,
+  stat,
+  sigLevel,
+  ascensionLevel = 0,
+}: {
+  prestigeData: McocPrestigeEndpoint[];
+  stat: McocPrestigeStat | undefined;
+  sigLevel: number;
+  ascensionLevel?: number;
+}) {
+  const basePrestige = calculateMcocPrestige(prestigeData, stat, sigLevel);
+  return applyAscensionToPrestige(basePrestige, stat?.rarity, ascensionLevel);
+}
+
+export function expandMcocPrestigeCurve({
+  prestigeData,
+  stat,
+  ascensionLevel = 0,
+}: {
+  prestigeData: McocPrestigeEndpoint[];
+  stat: McocPrestigeStat;
+  ascensionLevel?: number;
+}): McocPrestigePoint[] {
+  const maxSig = maxSigForRarity(stat.rarity);
+  const points: McocPrestigePoint[] = [];
+
+  for (let sig = 0; sig <= maxSig; sig++) {
+    const prestige = projectMcocPrestige({ prestigeData, stat, sigLevel: sig, ascensionLevel });
+    if (prestige != null) points.push({ sig, prestige });
+  }
+
+  return points;
+}
+
+export function projectMcocPrestigeFromCurve({
+  curve,
+  sigLevel,
+  rarity,
+  ascensionLevel = 0,
+}: {
+  curve: McocPrestigePoint[];
+  sigLevel: number;
+  rarity: number | null | undefined;
+  ascensionLevel?: number;
+}) {
+  const sig = clampSigForRarity(sigLevel, rarity);
+  const point = curve.find(p => p.sig === sig);
+  const basePrestige = point?.prestige ?? null;
+  return applyAscensionToPrestige(basePrestige, rarity, ascensionLevel);
 }

--- a/web/src/lib/roster-recommendation-service.ts
+++ b/web/src/lib/roster-recommendation-service.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { ChampionClass, Prisma } from "@prisma/client";
 import { ChampionImages } from "@/types/champion";
 import { ProfileRosterEntry, Recommendation, SigRecommendation } from "@/app/profile/roster/types";
-import { calculateMcocPrestige, maxSigForRarity } from "@/lib/mcoc-prestige";
+import { maxSigForRarity, projectMcocPrestige } from "@/lib/mcoc-prestige";
 
 interface RecommendationOptions {
     targetRank: number;
@@ -47,13 +47,12 @@ export async function calculateRosterRecommendations(
 
     const getCalculatedPrestige = (champId: number, rarity: number, rank: number, sig: number, ascensionLevel: number = 0): number => {
         const rows = prestigeLookup.get(`${champId}:${rarity}:${rank}`) ?? [];
-        let basePrestige = calculateMcocPrestige(rows, { rarity, rank, prestige: null }, sig) ?? 0;
-
-        if (basePrestige > 0 && rarity === 7 && ascensionLevel > 0) {
-            basePrestige = basePrestige * Math.pow(1.08, ascensionLevel);
-        }
-
-        return roundPrestigeToGameDisplay(basePrestige);
+        return projectMcocPrestige({
+            prestigeData: rows,
+            stat: { rarity, rank, prestige: null },
+            sigLevel: sig,
+            ascensionLevel,
+        }) ?? 0;
     };
 
     const rosterWithPrestige = roster.map(r => {
@@ -258,8 +257,4 @@ export async function calculateRosterRecommendations(
         recommendations,
         sigRecommendations
     };
-}
-
-function roundPrestigeToGameDisplay(value: number) {
-    return value > 0 ? Math.round(value / 10) * 10 : 0;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prestige projection now honors per-rarity ascension scaling (including 7-star ascension up to level 5), with improved game-display rounding.
  * Signature sliders and quick-jump values now adapt to rarity-based max signature values.
  * Roster prestige shown throughout the app now uses the new projection logic.

* **Bug Fixes / Validation**
  * Roster add/edit enforces ascension limits based on champion rarity.

* **Documentation**
  * Added a “CereBro Context” section describing the prestige projection rules.

* **Tests**
  * Added unit tests covering prestige projection and caps.

* **Chores**
  * Updated pinned package manager version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->