### PR TITLE
Add battlegrounds tournaments workspace

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,3 +47,9 @@ Player Profile is an MCOC account/profile stored in CereBro. A Discord user may 
 Active Player Profile is the Player Profile currently selected by its owning Discord user. It is not an activity, freshness, visibility, or status flag.
 
 Real Alliance is an Alliance intended to represent an actual MCOC alliance. Infrastructure records and empty orphan records are not Real Alliances.
+
+## Battlegrounds Tournaments
+
+Battlegrounds Tournaments is the organizer workspace for creating and running MCOC Battlegrounds events.
+
+It owns tournament scope, status, format, registration/check-in timing, seeded participants, optional battlegroup-aware field organization, and match records used by the tournament control page. Tournament scope can be Community for open/friendly events outside an alliance or Alliance for internal alliance friendlies. Bracket generation and match reporting build on this organizer model instead of replacing it.

--- a/docs/features.md
+++ b/docs/features.md
@@ -100,6 +100,14 @@ A unified suite of tools for managing Alliance War.
     *   **Defense:** Analyze performance by Node (lethality) or Defender (placement history).
     *   **Matchups:** Analyze Attacker success rates and find "Best Counters".
 
+### Battlegrounds Tournaments
+*   **Organizer Workspace:** `/battlegrounds/tournaments` gives players and alliance planners a dedicated tournament control surface for MCOC Battlegrounds events.
+*   **Community & Alliance Scope:** Tournaments can be community-hosted for players outside an alliance or alliance-scoped for internal friendly events.
+*   **Tournament Lifecycle:** Supports Draft, Registration, Check-in, Live, Finished, and Archived states so organizers can stage the event before matches begin.
+*   **Field Management:** Organizers can create tournaments, choose a format, add players, assign seeds, and keep battlegroup context visible when it exists.
+*   **Common Formats:** Supports single elimination, double elimination, Swiss, Swiss plus elimination top cut, round robin, and ladder tournament styles.
+*   **Bracket Foundation:** Match records are modeled separately from participants so bracket generation can be layered in without changing the organizer workflow.
+
 ### Quest Planning & Roster Integration
 A dedicated system for planning fights across complex quests (e.g., Story content, Everest runs).
 *   **Data Model:** `QuestCategory` -> `QuestPlan` -> `QuestEncounter` -> `QuestEncounterNode`.

--- a/prisma/migrations/20260603220500_add_battlegrounds_tournaments/migration.sql
+++ b/prisma/migrations/20260603220500_add_battlegrounds_tournaments/migration.sql
@@ -1,0 +1,78 @@
+CREATE TYPE "BattlegroundsTournamentFormat" AS ENUM ('SINGLE_ELIMINATION', 'SWISS', 'ROUND_ROBIN');
+CREATE TYPE "BattlegroundsTournamentStatus" AS ENUM ('DRAFT', 'REGISTRATION', 'CHECK_IN', 'LIVE', 'FINISHED', 'ARCHIVED');
+CREATE TYPE "TournamentParticipantStatus" AS ENUM ('INVITED', 'CONFIRMED', 'CHECKED_IN', 'DROPPED');
+CREATE TYPE "BattlegroundsMatchStatus" AS ENUM ('PENDING', 'READY', 'PLAYING', 'REPORTED', 'DISPUTED', 'FINAL');
+
+CREATE TABLE "BattlegroundsTournament" (
+  "id" TEXT NOT NULL,
+  "allianceId" TEXT NOT NULL,
+  "createdById" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "format" "BattlegroundsTournamentFormat" NOT NULL DEFAULT 'SINGLE_ELIMINATION',
+  "status" "BattlegroundsTournamentStatus" NOT NULL DEFAULT 'DRAFT',
+  "checkInStartsAt" TIMESTAMP(3),
+  "startsAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "BattlegroundsTournament_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "BattlegroundsTournamentParticipant" (
+  "id" TEXT NOT NULL,
+  "tournamentId" TEXT NOT NULL,
+  "playerId" TEXT NOT NULL,
+  "seed" INTEGER,
+  "battlegroup" INTEGER,
+  "status" "TournamentParticipantStatus" NOT NULL DEFAULT 'INVITED',
+  "checkedInAt" TIMESTAMP(3),
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "BattlegroundsTournamentParticipant_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "BattlegroundsTournamentMatch" (
+  "id" TEXT NOT NULL,
+  "tournamentId" TEXT NOT NULL,
+  "round" INTEGER NOT NULL,
+  "matchNumber" INTEGER NOT NULL,
+  "status" "BattlegroundsMatchStatus" NOT NULL DEFAULT 'PENDING',
+  "homeParticipantId" TEXT,
+  "awayParticipantId" TEXT,
+  "winnerParticipantId" TEXT,
+  "homeScore" INTEGER,
+  "awayScore" INTEGER,
+  "scheduledAt" TIMESTAMP(3),
+  "notes" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "BattlegroundsTournamentMatch_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "BattlegroundsTournament_allianceId_status_idx" ON "BattlegroundsTournament"("allianceId", "status");
+CREATE INDEX "BattlegroundsTournament_createdById_idx" ON "BattlegroundsTournament"("createdById");
+CREATE INDEX "BattlegroundsTournament_startsAt_idx" ON "BattlegroundsTournament"("startsAt");
+
+CREATE UNIQUE INDEX "BattlegroundsTournamentParticipant_tournamentId_playerId_key" ON "BattlegroundsTournamentParticipant"("tournamentId", "playerId");
+CREATE UNIQUE INDEX "BattlegroundsTournamentParticipant_tournamentId_seed_key" ON "BattlegroundsTournamentParticipant"("tournamentId", "seed");
+CREATE INDEX "BattlegroundsTournamentParticipant_playerId_idx" ON "BattlegroundsTournamentParticipant"("playerId");
+CREATE INDEX "BattlegroundsTournamentParticipant_tournamentId_battlegroup_idx" ON "BattlegroundsTournamentParticipant"("tournamentId", "battlegroup");
+
+CREATE UNIQUE INDEX "BattlegroundsTournamentMatch_tournamentId_round_matchNumber_key" ON "BattlegroundsTournamentMatch"("tournamentId", "round", "matchNumber");
+CREATE INDEX "BattlegroundsTournamentMatch_tournamentId_status_idx" ON "BattlegroundsTournamentMatch"("tournamentId", "status");
+CREATE INDEX "BattlegroundsTournamentMatch_homeParticipantId_idx" ON "BattlegroundsTournamentMatch"("homeParticipantId");
+CREATE INDEX "BattlegroundsTournamentMatch_awayParticipantId_idx" ON "BattlegroundsTournamentMatch"("awayParticipantId");
+CREATE INDEX "BattlegroundsTournamentMatch_winnerParticipantId_idx" ON "BattlegroundsTournamentMatch"("winnerParticipantId");
+
+ALTER TABLE "BattlegroundsTournament" ADD CONSTRAINT "BattlegroundsTournament_allianceId_fkey" FOREIGN KEY ("allianceId") REFERENCES "Alliance"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BattlegroundsTournament" ADD CONSTRAINT "BattlegroundsTournament_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "Player"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "BattlegroundsTournamentParticipant" ADD CONSTRAINT "BattlegroundsTournamentParticipant_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "BattlegroundsTournament"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BattlegroundsTournamentParticipant" ADD CONSTRAINT "BattlegroundsTournamentParticipant_playerId_fkey" FOREIGN KEY ("playerId") REFERENCES "Player"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BattlegroundsTournamentMatch" ADD CONSTRAINT "BattlegroundsTournamentMatch_tournamentId_fkey" FOREIGN KEY ("tournamentId") REFERENCES "BattlegroundsTournament"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "BattlegroundsTournamentMatch" ADD CONSTRAINT "BattlegroundsTournamentMatch_homeParticipantId_fkey" FOREIGN KEY ("homeParticipantId") REFERENCES "BattlegroundsTournamentParticipant"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "BattlegroundsTournamentMatch" ADD CONSTRAINT "BattlegroundsTournamentMatch_awayParticipantId_fkey" FOREIGN KEY ("awayParticipantId") REFERENCES "BattlegroundsTournamentParticipant"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "BattlegroundsTournamentMatch" ADD CONSTRAINT "BattlegroundsTournamentMatch_winnerParticipantId_fkey" FOREIGN KEY ("winnerParticipantId") REFERENCES "BattlegroundsTournamentParticipant"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260603223000_widen_battlegrounds_tournament_scope/migration.sql
+++ b/prisma/migrations/20260603223000_widen_battlegrounds_tournament_scope/migration.sql
@@ -1,0 +1,11 @@
+CREATE TYPE "BattlegroundsTournamentScope" AS ENUM ('COMMUNITY', 'ALLIANCE');
+
+ALTER TYPE "BattlegroundsTournamentFormat" ADD VALUE 'DOUBLE_ELIMINATION';
+ALTER TYPE "BattlegroundsTournamentFormat" ADD VALUE 'SWISS_TOP_CUT';
+ALTER TYPE "BattlegroundsTournamentFormat" ADD VALUE 'LADDER';
+
+ALTER TABLE "BattlegroundsTournament" ADD COLUMN "scope" "BattlegroundsTournamentScope" NOT NULL DEFAULT 'COMMUNITY';
+
+ALTER TABLE "BattlegroundsTournament" ALTER COLUMN "allianceId" DROP NOT NULL;
+ALTER TABLE "BattlegroundsTournament" DROP CONSTRAINT "BattlegroundsTournament_allianceId_fkey";
+ALTER TABLE "BattlegroundsTournament" ADD CONSTRAINT "BattlegroundsTournament_allianceId_fkey" FOREIGN KEY ("allianceId") REFERENCES "Alliance"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -306,6 +306,8 @@ model Player {
   rosterUploadsAsTarget RosterUploadEvent[]         @relation("RosterUploadTarget")
   submittedVideos    WarVideo[]                  @relation("SubmittedBy")
   supportDonations   SupportDonation[]
+  createdBattlegroundsTournaments BattlegroundsTournament[] @relation("BattlegroundsTournamentCreator")
+  battlegroundsTournamentEntries  BattlegroundsTournamentParticipant[]
 
   @@unique([discordId, ingameName])
   @@index([discordId])
@@ -397,6 +399,7 @@ model Alliance {
   rosterUploadEvents     RosterUploadEvent[]
   wars                   War[]
   defensePlans           WarDefensePlan[]
+  battlegroundsTournaments BattlegroundsTournament[]
 }
 
 model AllianceMembershipRequest {
@@ -532,6 +535,79 @@ model War {
 
   @@unique([allianceId, season, warNumber])
   @@index([allianceId])
+}
+
+model BattlegroundsTournament {
+  id              String                            @id @default(cuid())
+  allianceId      String?
+  createdById     String
+  name            String
+  description     String?
+  scope           BattlegroundsTournamentScope      @default(COMMUNITY)
+  format          BattlegroundsTournamentFormat     @default(SINGLE_ELIMINATION)
+  status          BattlegroundsTournamentStatus     @default(DRAFT)
+  checkInStartsAt DateTime?
+  startsAt        DateTime?
+  createdAt       DateTime                          @default(now())
+  updatedAt       DateTime                          @updatedAt
+  alliance        Alliance?                         @relation(fields: [allianceId], references: [id], onDelete: SetNull)
+  createdBy       Player                            @relation("BattlegroundsTournamentCreator", fields: [createdById], references: [id])
+  participants    BattlegroundsTournamentParticipant[]
+  matches         BattlegroundsTournamentMatch[]
+
+  @@index([allianceId, status])
+  @@index([createdById])
+  @@index([startsAt])
+}
+
+model BattlegroundsTournamentParticipant {
+  id           String                  @id @default(cuid())
+  tournamentId String
+  playerId     String
+  seed         Int?
+  battlegroup  Int?
+  status       TournamentParticipantStatus @default(INVITED)
+  checkedInAt  DateTime?
+  notes        String?
+  createdAt    DateTime                @default(now())
+  updatedAt    DateTime                @updatedAt
+  tournament   BattlegroundsTournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  player       Player                  @relation(fields: [playerId], references: [id], onDelete: Cascade)
+  homeMatches  BattlegroundsTournamentMatch[] @relation("BattlegroundsMatchHome")
+  awayMatches  BattlegroundsTournamentMatch[] @relation("BattlegroundsMatchAway")
+  wonMatches   BattlegroundsTournamentMatch[] @relation("BattlegroundsMatchWinner")
+
+  @@unique([tournamentId, playerId])
+  @@unique([tournamentId, seed])
+  @@index([playerId])
+  @@index([tournamentId, battlegroup])
+}
+
+model BattlegroundsTournamentMatch {
+  id              String                         @id @default(cuid())
+  tournamentId    String
+  round           Int
+  matchNumber     Int
+  status          BattlegroundsMatchStatus       @default(PENDING)
+  homeParticipantId String?
+  awayParticipantId String?
+  winnerParticipantId String?
+  homeScore       Int?
+  awayScore       Int?
+  scheduledAt     DateTime?
+  notes           String?
+  createdAt       DateTime                       @default(now())
+  updatedAt       DateTime                       @updatedAt
+  tournament      BattlegroundsTournament        @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
+  homeParticipant BattlegroundsTournamentParticipant? @relation("BattlegroundsMatchHome", fields: [homeParticipantId], references: [id], onDelete: SetNull)
+  awayParticipant BattlegroundsTournamentParticipant? @relation("BattlegroundsMatchAway", fields: [awayParticipantId], references: [id], onDelete: SetNull)
+  winnerParticipant BattlegroundsTournamentParticipant? @relation("BattlegroundsMatchWinner", fields: [winnerParticipantId], references: [id], onDelete: SetNull)
+
+  @@unique([tournamentId, round, matchNumber])
+  @@index([tournamentId, status])
+  @@index([homeParticipantId])
+  @@index([awayParticipantId])
+  @@index([winnerParticipantId])
 }
 
 model WarDefensePlan {
@@ -1173,6 +1249,45 @@ enum WarStatus {
 enum WarMapType {
   STANDARD
   BIG_THING
+}
+
+enum BattlegroundsTournamentFormat {
+  SINGLE_ELIMINATION
+  DOUBLE_ELIMINATION
+  SWISS
+  SWISS_TOP_CUT
+  ROUND_ROBIN
+  LADDER
+}
+
+enum BattlegroundsTournamentScope {
+  COMMUNITY
+  ALLIANCE
+}
+
+enum BattlegroundsTournamentStatus {
+  DRAFT
+  REGISTRATION
+  CHECK_IN
+  LIVE
+  FINISHED
+  ARCHIVED
+}
+
+enum TournamentParticipantStatus {
+  INVITED
+  CONFIRMED
+  CHECKED_IN
+  DROPPED
+}
+
+enum BattlegroundsMatchStatus {
+  PENDING
+  READY
+  PLAYING
+  REPORTED
+  DISPUTED
+  FINAL
 }
 
 enum DuelStatus {

--- a/web/src/app/battlegrounds/tournaments/actions.ts
+++ b/web/src/app/battlegrounds/tournaments/actions.ts
@@ -1,0 +1,271 @@
+'use server';
+
+import {
+  BattlegroundsTournamentFormat,
+  BattlegroundsTournamentScope,
+  BattlegroundsTournamentStatus,
+  TournamentParticipantStatus,
+} from "@prisma/client";
+import { revalidatePath } from "next/cache";
+import { getUserPlayerWithAlliance } from "@/lib/auth-helpers";
+import { canPlanAllianceWar } from "@/lib/alliance-permissions";
+import { prisma } from "@/lib/prisma";
+import { withActionContext } from "@/lib/with-request-context";
+
+const TOURNAMENTS_PATH = "/battlegrounds/tournaments";
+
+export type TournamentActionResult =
+  | { success: true }
+  | { success: false; error: string };
+
+async function requireTournamentPlanner() {
+  const player = await getUserPlayerWithAlliance();
+
+  if (!player) {
+    throw new Error("You must be logged in to manage tournaments.");
+  }
+
+  return player;
+}
+
+function canManageTournament(
+  player: Awaited<ReturnType<typeof requireTournamentPlanner>>,
+  tournament: { createdById: string; allianceId: string | null }
+) {
+  if (player.isBotAdmin || tournament.createdById === player.id) return true;
+
+  if (
+    tournament.allianceId &&
+    player.allianceId === tournament.allianceId &&
+    canPlanAllianceWar(player, player.isBotAdmin)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function parseScope(value: FormDataEntryValue | null, hasAlliance: boolean) {
+  if (value === BattlegroundsTournamentScope.ALLIANCE && hasAlliance) {
+    return BattlegroundsTournamentScope.ALLIANCE;
+  }
+
+  return BattlegroundsTournamentScope.COMMUNITY;
+}
+
+function readTrimmedString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function readOptionalDate(formData: FormData, key: string) {
+  const value = readTrimmedString(formData, key);
+  if (!value) return null;
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return undefined;
+  return parsed;
+}
+
+function parseFormat(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") return BattlegroundsTournamentFormat.SINGLE_ELIMINATION;
+  return Object.values(BattlegroundsTournamentFormat).includes(value as BattlegroundsTournamentFormat)
+    ? value as BattlegroundsTournamentFormat
+    : BattlegroundsTournamentFormat.SINGLE_ELIMINATION;
+}
+
+function parseParticipantStatus(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") return TournamentParticipantStatus.CONFIRMED;
+  return Object.values(TournamentParticipantStatus).includes(value as TournamentParticipantStatus)
+    ? value as TournamentParticipantStatus
+    : TournamentParticipantStatus.CONFIRMED;
+}
+
+export const createTournament = withActionContext(
+  "createBattlegroundsTournament",
+  async (formData: FormData): Promise<TournamentActionResult> => {
+    const player = await requireTournamentPlanner();
+    const name = readTrimmedString(formData, "name");
+    const description = readTrimmedString(formData, "description");
+    const startsAt = readOptionalDate(formData, "startsAt");
+    const checkInStartsAt = readOptionalDate(formData, "checkInStartsAt");
+    const scope = parseScope(formData.get("scope"), !!player.allianceId);
+
+    if (!name) {
+      return { success: false, error: "Tournament name is required." };
+    }
+
+    if (startsAt === undefined || checkInStartsAt === undefined) {
+      return { success: false, error: "Use valid dates or leave date fields empty." };
+    }
+
+    await prisma.battlegroundsTournament.create({
+      data: {
+        allianceId: scope === BattlegroundsTournamentScope.ALLIANCE ? player.allianceId : null,
+        createdById: player.id,
+        name,
+        description: description || null,
+        scope,
+        format: parseFormat(formData.get("format")),
+        startsAt,
+        checkInStartsAt,
+      },
+    });
+
+    revalidatePath(TOURNAMENTS_PATH);
+    return { success: true };
+  }
+);
+
+export const updateTournamentStatus = withActionContext(
+  "updateBattlegroundsTournamentStatus",
+  async (tournamentId: string, status: BattlegroundsTournamentStatus): Promise<TournamentActionResult> => {
+    const player = await requireTournamentPlanner();
+
+    if (!Object.values(BattlegroundsTournamentStatus).includes(status)) {
+      return { success: false, error: "Unknown tournament status." };
+    }
+
+    const tournament = await prisma.battlegroundsTournament.findUnique({
+      where: { id: tournamentId },
+      select: { allianceId: true, createdById: true },
+    });
+
+    if (!tournament || !canManageTournament(player, tournament)) {
+      return { success: false, error: "Tournament not found." };
+    }
+
+    await prisma.battlegroundsTournament.update({
+      where: { id: tournamentId },
+      data: { status },
+    });
+
+    revalidatePath(TOURNAMENTS_PATH);
+    return { success: true };
+  }
+);
+
+export const addTournamentParticipant = withActionContext(
+  "addBattlegroundsTournamentParticipant",
+  async (formData: FormData): Promise<TournamentActionResult> => {
+    const player = await requireTournamentPlanner();
+    const tournamentId = readTrimmedString(formData, "tournamentId");
+    const playerId = readTrimmedString(formData, "playerId");
+    const rawSeed = readTrimmedString(formData, "seed");
+
+    if (!tournamentId || !playerId) {
+      return { success: false, error: "Choose a tournament and player." };
+    }
+
+    const [tournament, entrant] = await Promise.all([
+      prisma.battlegroundsTournament.findUnique({
+        where: { id: tournamentId },
+        select: { allianceId: true, createdById: true, scope: true },
+      }),
+      prisma.player.findUnique({
+        where: { id: playerId },
+        select: { id: true, allianceId: true, battlegroup: true },
+      }),
+    ]);
+
+    if (!tournament || !canManageTournament(player, tournament)) {
+      return { success: false, error: "Tournament not found." };
+    }
+
+    if (!entrant) {
+      return { success: false, error: "Player not found." };
+    }
+
+    if (tournament.scope === BattlegroundsTournamentScope.ALLIANCE && entrant.allianceId !== tournament.allianceId) {
+      return { success: false, error: "That player is not in this alliance tournament." };
+    }
+
+    const seed = rawSeed ? Number(rawSeed) : null;
+    if (seed !== null && (!Number.isInteger(seed) || seed < 1)) {
+      return { success: false, error: "Seed must be a positive whole number." };
+    }
+
+    try {
+      await prisma.battlegroundsTournamentParticipant.create({
+        data: {
+          tournamentId,
+          playerId,
+          seed,
+          battlegroup: entrant.battlegroup,
+          status: parseParticipantStatus(formData.get("status")),
+        },
+      });
+    } catch {
+      return { success: false, error: "This player or seed is already in the tournament." };
+    }
+
+    revalidatePath(TOURNAMENTS_PATH);
+    return { success: true };
+  }
+);
+
+export const removeTournamentParticipant = withActionContext(
+  "removeBattlegroundsTournamentParticipant",
+  async (participantId: string): Promise<TournamentActionResult> => {
+    const player = await requireTournamentPlanner();
+
+    const participant = await prisma.battlegroundsTournamentParticipant.findUnique({
+      where: { id: participantId },
+      select: { tournament: { select: { allianceId: true, createdById: true } } },
+    });
+
+    if (!participant || !canManageTournament(player, participant.tournament)) {
+      return { success: false, error: "Participant not found." };
+    }
+
+    await prisma.battlegroundsTournamentParticipant.delete({
+      where: { id: participantId },
+    });
+
+    revalidatePath(TOURNAMENTS_PATH);
+    return { success: true };
+  }
+);
+
+export const joinTournament = withActionContext(
+  "joinBattlegroundsTournament",
+  async (tournamentId: string): Promise<TournamentActionResult> => {
+    const player = await requireTournamentPlanner();
+
+    const tournament = await prisma.battlegroundsTournament.findUnique({
+      where: { id: tournamentId },
+      select: { id: true, scope: true, allianceId: true, status: true },
+    });
+
+    if (!tournament) {
+      return { success: false, error: "Tournament not found." };
+    }
+
+    if (!["REGISTRATION", "CHECK_IN"].includes(tournament.status)) {
+      return { success: false, error: "Registration is not open for this tournament." };
+    }
+
+    if (tournament.scope === BattlegroundsTournamentScope.ALLIANCE && tournament.allianceId !== player.allianceId) {
+      return { success: false, error: "This tournament is limited to its alliance." };
+    }
+
+    try {
+      await prisma.battlegroundsTournamentParticipant.create({
+        data: {
+          tournamentId,
+          playerId: player.id,
+          battlegroup: player.allianceId === tournament.allianceId ? player.battlegroup : null,
+          status: tournament.status === "CHECK_IN"
+            ? TournamentParticipantStatus.CHECKED_IN
+            : TournamentParticipantStatus.CONFIRMED,
+          checkedInAt: tournament.status === "CHECK_IN" ? new Date() : null,
+        },
+      });
+    } catch {
+      return { success: false, error: "You are already in this tournament." };
+    }
+
+    revalidatePath(TOURNAMENTS_PATH);
+    return { success: true };
+  }
+);

--- a/web/src/app/battlegrounds/tournaments/page.tsx
+++ b/web/src/app/battlegrounds/tournaments/page.tsx
@@ -1,0 +1,162 @@
+import type { Metadata } from "next";
+import { Swords, Trophy } from "lucide-react";
+import { getUserPlayerWithAlliance } from "@/lib/auth-helpers";
+import { canPlanAllianceWar } from "@/lib/alliance-permissions";
+import { prisma } from "@/lib/prisma";
+import logger from "@/lib/logger";
+import { BattlegroundsTournamentsClient } from "./tournaments-client";
+
+export const metadata: Metadata = {
+  title: "Battlegrounds Tournaments - CereBro",
+  description: "Create, organize, and manage alliance Battlegrounds tournaments.",
+};
+
+export const dynamic = "force-dynamic";
+
+export default async function BattlegroundsTournamentsPage() {
+  const player = await getUserPlayerWithAlliance();
+
+  if (!player) {
+    return (
+      <div className="container mx-auto max-w-6xl px-4 py-16">
+        <div className="rounded-lg border border-slate-800 bg-slate-950/60 p-10 text-center">
+          <Trophy className="mx-auto h-12 w-12 text-slate-700" />
+          <h1 className="mt-4 text-2xl font-bold text-white">Login Required</h1>
+          <p className="mx-auto mt-2 max-w-md text-sm text-slate-400">
+            Sign in with Discord and select a CereBro profile to join or host Battlegrounds tournaments.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  logger.info(
+    { userId: player.id, allianceId: player.allianceId },
+    "User accessing Battlegrounds Tournaments page"
+  );
+
+  const [members, tournaments] = await Promise.all([
+    prisma.player.findMany({
+      where: player.allianceId
+        ? {
+            OR: [
+              { allianceId: player.allianceId },
+              { allianceId: null },
+            ],
+          }
+        : { allianceId: null },
+      select: {
+        id: true,
+        ingameName: true,
+        battlegroup: true,
+        championPrestige: true,
+        avatar: true,
+      },
+      orderBy: [
+        { battlegroup: "asc" },
+        { ingameName: "asc" },
+      ],
+    }),
+    prisma.battlegroundsTournament.findMany({
+      where: {
+        OR: [
+          { scope: "COMMUNITY" },
+          ...(player.allianceId ? [{ allianceId: player.allianceId }] : []),
+          { createdById: player.id },
+        ],
+      },
+      include: {
+        createdBy: { select: { ingameName: true } },
+        alliance: { select: { name: true } },
+        participants: {
+          include: {
+            player: {
+              select: {
+                id: true,
+                ingameName: true,
+                battlegroup: true,
+                championPrestige: true,
+                avatar: true,
+              },
+            },
+          },
+          orderBy: [
+            { seed: "asc" },
+            { createdAt: "asc" },
+          ],
+        },
+        _count: { select: { matches: true } },
+      },
+      orderBy: [
+        { status: "asc" },
+        { startsAt: "asc" },
+        { createdAt: "desc" },
+      ],
+    }),
+  ]);
+
+  const canManageAllianceTournaments = canPlanAllianceWar(player, player.isBotAdmin);
+  const manageableTournamentIds = tournaments
+    .filter((tournament) => {
+      if (player.isBotAdmin || tournament.createdById === player.id) return true;
+      return !!tournament.allianceId &&
+        tournament.allianceId === player.allianceId &&
+        canManageAllianceTournaments;
+    })
+    .map((tournament) => tournament.id);
+  const bgColors = {
+    1: player.alliance?.battlegroup1Color || "#ef4444",
+    2: player.alliance?.battlegroup2Color || "#22c55e",
+    3: player.alliance?.battlegroup3Color || "#3b82f6",
+  };
+
+  const serializedTournaments = tournaments.map((tournament) => ({
+    ...tournament,
+    startsAt: tournament.startsAt?.toISOString() ?? null,
+    checkInStartsAt: tournament.checkInStartsAt?.toISOString() ?? null,
+    createdAt: tournament.createdAt.toISOString(),
+    updatedAt: tournament.updatedAt.toISOString(),
+    participants: tournament.participants.map((participant) => ({
+      ...participant,
+      checkedInAt: participant.checkedInAt?.toISOString() ?? null,
+      createdAt: participant.createdAt.toISOString(),
+      updatedAt: participant.updatedAt.toISOString(),
+    })),
+  }));
+
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.12),transparent_32%),radial-gradient(circle_at_top_right,rgba(16,185,129,0.10),transparent_30%)]">
+      <div className="container mx-auto max-w-7xl px-4 py-8 sm:px-6">
+        <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="mb-3 inline-flex items-center gap-2 rounded-md border border-cyan-500/20 bg-cyan-500/10 px-3 py-1 text-xs font-bold uppercase tracking-widest text-cyan-200">
+              <Swords className="h-3.5 w-3.5" />
+              Battlegrounds
+            </div>
+            <h1 className="text-3xl font-black tracking-tight text-white sm:text-4xl">
+              Tournament Control
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+              Build the field, stage registration, manage check-ins, and keep alliance context visible while your BG event comes together.
+            </p>
+          </div>
+          <div className="rounded-lg border border-slate-800 bg-slate-950/70 px-4 py-3">
+            <p className="text-xs font-bold uppercase tracking-widest text-slate-500">Alliance</p>
+            <p className="font-semibold text-slate-200">{player.alliance?.name ?? "Alliance"}</p>
+          </div>
+        </div>
+
+        <BattlegroundsTournamentsClient
+          allianceName={player.alliance?.name ?? "Alliance"}
+          hasAlliance={!!player.allianceId}
+          currentPlayerId={player.id}
+          bgColors={bgColors}
+          players={members}
+          tournaments={serializedTournaments}
+          canCreate={true}
+          manageableTournamentIds={manageableTournamentIds}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/battlegrounds/tournaments/tournaments-client.tsx
+++ b/web/src/app/battlegrounds/tournaments/tournaments-client.tsx
@@ -1,0 +1,596 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import {
+  BattlegroundsTournamentFormat,
+  BattlegroundsTournamentScope,
+  BattlegroundsTournamentStatus,
+  TournamentParticipantStatus,
+} from "@prisma/client";
+import {
+  CalendarClock,
+  CheckCircle2,
+  CircleDot,
+  ClipboardList,
+  Flag,
+  Play,
+  Plus,
+  Swords,
+  Trash2,
+  Trophy,
+  Users,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import {
+  addTournamentParticipant,
+  createTournament,
+  joinTournament,
+  removeTournamentParticipant,
+  updateTournamentStatus,
+  type TournamentActionResult,
+} from "./actions";
+
+export type TournamentMember = {
+  id: string;
+  ingameName: string;
+  battlegroup: number | null;
+  championPrestige: number | null;
+  avatar: string | null;
+};
+
+export type TournamentSummary = {
+  id: string;
+  name: string;
+  description: string | null;
+  scope: BattlegroundsTournamentScope;
+  format: BattlegroundsTournamentFormat;
+  status: BattlegroundsTournamentStatus;
+  startsAt: string | null;
+  checkInStartsAt: string | null;
+  createdAt: string;
+  allianceId: string | null;
+  createdById: string;
+  createdBy: { ingameName: string };
+  participants: Array<{
+    id: string;
+    seed: number | null;
+    battlegroup: number | null;
+    status: TournamentParticipantStatus;
+    checkedInAt: string | null;
+    player: TournamentMember;
+  }>;
+  _count: { matches: number };
+};
+
+type Props = {
+  allianceName: string;
+  hasAlliance: boolean;
+  currentPlayerId: string;
+  bgColors: Record<number, string>;
+  players: TournamentMember[];
+  tournaments: TournamentSummary[];
+  canCreate: boolean;
+  manageableTournamentIds: string[];
+};
+
+const statusLabels: Record<BattlegroundsTournamentStatus, string> = {
+  DRAFT: "Draft",
+  REGISTRATION: "Registration",
+  CHECK_IN: "Check-in",
+  LIVE: "Live",
+  FINISHED: "Finished",
+  ARCHIVED: "Archived",
+};
+
+const formatLabels: Record<BattlegroundsTournamentFormat, string> = {
+  SINGLE_ELIMINATION: "Single Elim",
+  DOUBLE_ELIMINATION: "Double Elim",
+  SWISS: "Swiss",
+  SWISS_TOP_CUT: "Swiss + Top Cut",
+  ROUND_ROBIN: "Round Robin",
+  LADDER: "Ladder",
+};
+
+const scopeLabels: Record<BattlegroundsTournamentScope, string> = {
+  COMMUNITY: "Community",
+  ALLIANCE: "Alliance",
+};
+
+const participantLabels: Record<TournamentParticipantStatus, string> = {
+  INVITED: "Invited",
+  CONFIRMED: "Confirmed",
+  CHECKED_IN: "Checked in",
+  DROPPED: "Dropped",
+};
+
+function formatDate(value: string | null) {
+  if (!value) return "Unscheduled";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function statusTone(status: BattlegroundsTournamentStatus) {
+  switch (status) {
+    case "LIVE":
+      return "border-emerald-500/40 bg-emerald-500/15 text-emerald-200";
+    case "CHECK_IN":
+      return "border-sky-500/40 bg-sky-500/15 text-sky-200";
+    case "REGISTRATION":
+      return "border-amber-500/40 bg-amber-500/15 text-amber-200";
+    case "FINISHED":
+      return "border-violet-500/40 bg-violet-500/15 text-violet-200";
+    case "ARCHIVED":
+      return "border-slate-700 bg-slate-900 text-slate-400";
+    default:
+      return "border-slate-700 bg-slate-900 text-slate-300";
+  }
+}
+
+function sortParticipants(tournament: TournamentSummary) {
+  return [...tournament.participants].sort((a, b) => {
+    const aSeed = a.seed ?? 9999;
+    const bSeed = b.seed ?? 9999;
+    if (aSeed !== bSeed) return aSeed - bSeed;
+    const aBg = a.battlegroup ?? 99;
+    const bBg = b.battlegroup ?? 99;
+    if (aBg !== bBg) return aBg - bBg;
+    return a.player.ingameName.localeCompare(b.player.ingameName);
+  });
+}
+
+export function BattlegroundsTournamentsClient({
+  allianceName,
+  hasAlliance,
+  currentPlayerId,
+  bgColors,
+  players,
+  tournaments,
+  canCreate,
+  manageableTournamentIds,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [selectedTournamentId, setSelectedTournamentId] = useState(tournaments[0]?.id ?? null);
+  const [message, setMessage] = useState<string | null>(null);
+  const selectedTournament = tournaments.find((tournament) => tournament.id === selectedTournamentId) ?? tournaments[0] ?? null;
+  const manageableTournamentIdSet = useMemo(
+    () => new Set(manageableTournamentIds),
+    [manageableTournamentIds]
+  );
+
+  const availableMembers = useMemo(() => {
+    const participantIds = new Set(selectedTournament?.participants.map((entry) => entry.player.id) ?? []);
+    return players
+      .filter((member) => !participantIds.has(member.id))
+      .filter((member) => selectedTournament?.scope !== "ALLIANCE" || member.battlegroup !== null)
+      .sort((a, b) => {
+        const aBg = a.battlegroup ?? 99;
+        const bBg = b.battlegroup ?? 99;
+        if (aBg !== bBg) return aBg - bBg;
+        return a.ingameName.localeCompare(b.ingameName);
+      });
+  }, [players, selectedTournament]);
+
+  const runAction = (action: () => Promise<TournamentActionResult>) => {
+    setMessage(null);
+    startTransition(async () => {
+      const result = await action();
+      if (!result.success) {
+        setMessage(result.error);
+        return;
+      }
+      router.refresh();
+    });
+  };
+
+  const participants = selectedTournament ? sortParticipants(selectedTournament) : [];
+  const isCurrentUserEntered = participants.some((entry) => entry.player.id === currentPlayerId);
+  const canManageSelected = !!selectedTournament && (
+    manageableTournamentIdSet.has(selectedTournament.id) ||
+    selectedTournament.createdById === currentPlayerId
+  );
+  const canJoinSelected = !!selectedTournament &&
+    !isCurrentUserEntered &&
+    ["REGISTRATION", "CHECK_IN"].includes(selectedTournament.status);
+  const checkedInCount = participants.filter((entry) => entry.status === "CHECKED_IN").length;
+  const bgCounts = [1, 2, 3].map((bg) => ({
+    bg,
+    count: participants.filter((entry) => entry.battlegroup === bg).length,
+  }));
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
+        <Card className="border-slate-800/70 bg-slate-950/60 p-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-cyan-500/25 bg-cyan-500/10 text-cyan-200">
+              <Trophy className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-widest text-slate-500">Tournaments</p>
+              <p className="text-2xl font-black text-white">{tournaments.length}</p>
+            </div>
+          </div>
+        </Card>
+        <Card className="border-slate-800/70 bg-slate-950/60 p-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-emerald-500/25 bg-emerald-500/10 text-emerald-200">
+              <Play className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-widest text-slate-500">Active</p>
+              <p className="text-2xl font-black text-white">
+                {tournaments.filter((tournament) => ["REGISTRATION", "CHECK_IN", "LIVE"].includes(tournament.status)).length}
+              </p>
+            </div>
+          </div>
+        </Card>
+        <Card className="border-slate-800/70 bg-slate-950/60 p-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-amber-500/25 bg-amber-500/10 text-amber-200">
+              <Users className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-widest text-slate-500">Current Field</p>
+              <p className="text-2xl font-black text-white">{participants.length}</p>
+            </div>
+          </div>
+        </Card>
+        <Card className="border-slate-800/70 bg-slate-950/60 p-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-violet-500/25 bg-violet-500/10 text-violet-200">
+              <CheckCircle2 className="h-5 w-5" />
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-widest text-slate-500">Checked In</p>
+              <p className="text-2xl font-black text-white">{checkedInCount}</p>
+            </div>
+          </div>
+        </Card>
+      </div>
+
+      {message && (
+        <div className="rounded-lg border border-red-500/30 bg-red-950/30 px-4 py-3 text-sm text-red-200">
+          {message}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-[360px_1fr]">
+        <section className="space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-bold text-white">Tournament Queue</h2>
+              <p className="text-xs text-slate-500">{allianceName}</p>
+            </div>
+            {canCreate && (
+              <Dialog>
+                <DialogTrigger asChild>
+                  <Button className="gap-2 bg-cyan-500 text-slate-950 hover:bg-cyan-400">
+                    <Plus className="h-4 w-4" />
+                    Create
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="border-slate-800 bg-slate-950 text-slate-100">
+                  <DialogHeader>
+                    <DialogTitle>Create Battlegrounds Tournament</DialogTitle>
+                  </DialogHeader>
+                  <form
+                    className="space-y-4"
+                    action={(formData) => runAction(() => createTournament(formData))}
+                  >
+                    <div className="space-y-2">
+                      <Label htmlFor="name">Name</Label>
+                      <Input id="name" name="name" placeholder="Friday BG Gauntlet" className="border-slate-800 bg-slate-900" />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="description">Organizer notes</Label>
+                      <Textarea id="description" name="description" placeholder="Rules, deck limits, rewards, stream notes..." className="border-slate-800 bg-slate-900" />
+                    </div>
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label htmlFor="scope">Scope</Label>
+                        <select id="scope" name="scope" className="h-9 w-full rounded-md border border-slate-800 bg-slate-900 px-3 text-sm text-slate-100">
+                          <option value="COMMUNITY">Community / invite anyone</option>
+                          {hasAlliance && <option value="ALLIANCE">Alliance only</option>}
+                        </select>
+                      </div>
+                      <div className="space-y-2">
+                        <Label htmlFor="format">Format</Label>
+                        <select id="format" name="format" className="h-9 w-full rounded-md border border-slate-800 bg-slate-900 px-3 text-sm text-slate-100">
+                          <option value="SINGLE_ELIMINATION">Single Elimination</option>
+                          <option value="DOUBLE_ELIMINATION">Double Elimination</option>
+                          <option value="SWISS">Swiss</option>
+                          <option value="SWISS_TOP_CUT">Swiss + Top Cut</option>
+                          <option value="ROUND_ROBIN">Round Robin</option>
+                          <option value="LADDER">Ladder</option>
+                        </select>
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                      <div className="space-y-2">
+                        <Label htmlFor="startsAt">Start time</Label>
+                        <Input id="startsAt" name="startsAt" type="datetime-local" className="border-slate-800 bg-slate-900" />
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="checkInStartsAt">Check-in opens</Label>
+                      <Input id="checkInStartsAt" name="checkInStartsAt" type="datetime-local" className="border-slate-800 bg-slate-900" />
+                    </div>
+                    <Button disabled={isPending} className="w-full bg-cyan-500 text-slate-950 hover:bg-cyan-400">
+                      <Plus className="h-4 w-4" />
+                      Create tournament
+                    </Button>
+                  </form>
+                </DialogContent>
+              </Dialog>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            {tournaments.length === 0 && (
+              <Card className="border-dashed border-slate-800 bg-slate-950/50 p-6 text-center">
+                <ClipboardList className="mx-auto h-10 w-10 text-slate-700" />
+                <p className="mt-3 font-semibold text-slate-300">No tournaments yet</p>
+                <p className="mt-1 text-sm text-slate-500">Create one to start shaping the Battlegrounds flow.</p>
+              </Card>
+            )}
+            {tournaments.map((tournament) => (
+              <button
+                key={tournament.id}
+                onClick={() => setSelectedTournamentId(tournament.id)}
+                className={cn(
+                  "w-full rounded-lg border p-4 text-left transition-colors",
+                  selectedTournament?.id === tournament.id
+                    ? "border-cyan-500/50 bg-cyan-500/10"
+                    : "border-slate-800 bg-slate-950/50 hover:border-slate-700"
+                )}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate font-bold text-white">{tournament.name}</p>
+                    <p className="mt-1 text-xs text-slate-500">{formatLabels[tournament.format]} by {tournament.createdBy.ingameName}</p>
+                  </div>
+                  <Badge variant="outline" className={cn("shrink-0", statusTone(tournament.status))}>
+                    {statusLabels[tournament.status]}
+                  </Badge>
+                </div>
+                <div className="mt-4 grid grid-cols-3 gap-2 text-xs text-slate-400">
+                  <span className="flex items-center gap-1.5"><Users className="h-3.5 w-3.5" />{tournament.participants.length}</span>
+                  <span className="flex items-center gap-1.5"><Swords className="h-3.5 w-3.5" />{scopeLabels[tournament.scope]}</span>
+                  <span className="flex items-center gap-1.5"><CalendarClock className="h-3.5 w-3.5" />{formatDate(tournament.startsAt)}</span>
+                </div>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="min-w-0">
+          {!selectedTournament ? (
+            <Card className="border-slate-800 bg-slate-950/50 p-10 text-center">
+              <Trophy className="mx-auto h-12 w-12 text-slate-700" />
+              <p className="mt-3 text-lg font-bold text-slate-300">Create a tournament to open the organizer view.</p>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              <Card className="overflow-hidden border-slate-800/70 bg-slate-950/70">
+                <div className="border-b border-slate-800 p-5">
+                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="text-2xl font-black tracking-tight text-white">{selectedTournament.name}</h2>
+                        <Badge variant="outline" className={cn(statusTone(selectedTournament.status))}>
+                          {statusLabels[selectedTournament.status]}
+                        </Badge>
+                        <Badge variant="outline" className="border-slate-700 text-slate-400">
+                          {formatLabels[selectedTournament.format]}
+                        </Badge>
+                        <Badge variant="outline" className="border-cyan-500/30 bg-cyan-500/10 text-cyan-200">
+                          {scopeLabels[selectedTournament.scope]}
+                        </Badge>
+                      </div>
+                      {selectedTournament.description && (
+                        <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">{selectedTournament.description}</p>
+                      )}
+                    </div>
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                    {canJoinSelected && (
+                      <Button
+                        disabled={isPending}
+                        onClick={() => runAction(() => joinTournament(selectedTournament.id))}
+                        className="bg-emerald-500 text-slate-950 hover:bg-emerald-400"
+                      >
+                        <CheckCircle2 className="h-4 w-4" />
+                        Join
+                      </Button>
+                    )}
+                    {canManageSelected && (
+                      <Select
+                        value={selectedTournament.status}
+                        onValueChange={(value) => runAction(() => updateTournamentStatus(selectedTournament.id, value as BattlegroundsTournamentStatus))}
+                      >
+                        <SelectTrigger className="w-full border-slate-800 bg-slate-900 text-slate-100 sm:w-48">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent className="border-slate-800 bg-slate-950 text-slate-100">
+                          {Object.values(BattlegroundsTournamentStatus).map((status) => (
+                            <SelectItem key={status} value={status}>{statusLabels[status]}</SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-1 border-b border-slate-800 md:grid-cols-3">
+                  <div className="border-b border-slate-800 p-5 md:border-b-0 md:border-r">
+                    <p className="text-xs font-bold uppercase tracking-widest text-slate-500">Start</p>
+                    <p className="mt-1 font-semibold text-slate-200">{formatDate(selectedTournament.startsAt)}</p>
+                  </div>
+                  <div className="border-b border-slate-800 p-5 md:border-b-0 md:border-r">
+                    <p className="text-xs font-bold uppercase tracking-widest text-slate-500">Check-in</p>
+                    <p className="mt-1 font-semibold text-slate-200">{formatDate(selectedTournament.checkInStartsAt)}</p>
+                  </div>
+                  <div className="p-5">
+                    <p className="text-xs font-bold uppercase tracking-widest text-slate-500">BG Spread</p>
+                    <div className="mt-2 flex gap-2">
+                      {bgCounts.map(({ bg, count }) => (
+                        <span key={bg} className="inline-flex items-center gap-1.5 rounded-md border border-slate-800 bg-slate-900 px-2 py-1 text-xs text-slate-300">
+                          <span className="h-2 w-2 rounded-full" style={{ backgroundColor: bgColors[bg] }} />
+                          BG{bg}: {count}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+
+                {canManageSelected && (
+                  <form
+                    className="grid grid-cols-1 gap-3 border-b border-slate-800 p-4 lg:grid-cols-[1fr_90px_150px_auto]"
+                    action={(formData) => runAction(() => addTournamentParticipant(formData))}
+                  >
+                    <input type="hidden" name="tournamentId" value={selectedTournament.id} />
+                    <select name="playerId" className="h-9 rounded-md border border-slate-800 bg-slate-900 px-3 text-sm text-slate-100">
+                      <option value="">Add player...</option>
+                      {availableMembers.map((member) => (
+                        <option key={member.id} value={member.id}>
+                        {member.ingameName}{member.battlegroup ? ` - BG${member.battlegroup}` : " - Community"}
+                        </option>
+                      ))}
+                    </select>
+                    <Input name="seed" inputMode="numeric" placeholder="Seed" className="border-slate-800 bg-slate-900" />
+                    <select name="status" defaultValue="CONFIRMED" className="h-9 rounded-md border border-slate-800 bg-slate-900 px-3 text-sm text-slate-100">
+                      <option value="INVITED">Invited</option>
+                      <option value="CONFIRMED">Confirmed</option>
+                      <option value="CHECKED_IN">Checked in</option>
+                    </select>
+                    <Button disabled={isPending} className="bg-slate-100 text-slate-950 hover:bg-white">
+                      <Plus className="h-4 w-4" />
+                      Add
+                    </Button>
+                  </form>
+                )}
+
+                <div className="overflow-x-auto">
+                  <table className="w-full min-w-[720px] text-sm">
+                    <thead className="border-b border-slate-800 bg-slate-950 text-xs uppercase tracking-widest text-slate-500">
+                      <tr>
+                        <th className="w-20 px-4 py-3 text-left">Seed</th>
+                        <th className="px-4 py-3 text-left">Player</th>
+                        <th className="px-4 py-3 text-left">Battlegroup</th>
+                        <th className="px-4 py-3 text-left">Prestige</th>
+                        <th className="px-4 py-3 text-left">Status</th>
+                        {canManageSelected && <th className="w-16 px-4 py-3 text-right">Ops</th>}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {participants.length === 0 && (
+                        <tr>
+                          <td colSpan={canManageSelected ? 6 : 5} className="px-4 py-12 text-center text-slate-500">
+                            No entrants yet. Add alliance members to shape the field.
+                          </td>
+                        </tr>
+                      )}
+                      {participants.map((entry) => (
+                        <tr key={entry.id} className="border-b border-slate-900/80">
+                          <td className="px-4 py-3 font-mono font-bold text-slate-300">{entry.seed ?? "-"}</td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-3">
+                              <div className="flex h-8 w-8 items-center justify-center rounded-md border border-slate-800 bg-slate-900 text-xs font-bold text-slate-300">
+                                {entry.player.ingameName.slice(0, 2).toUpperCase()}
+                              </div>
+                              <span className="font-semibold text-slate-200">{entry.player.ingameName}</span>
+                            </div>
+                          </td>
+                          <td className="px-4 py-3">
+                            {entry.battlegroup ? (
+                              <span className="inline-flex items-center gap-2 rounded-md border border-slate-800 bg-slate-900 px-2 py-1 text-xs font-bold text-slate-300">
+                                <span className="h-2 w-2 rounded-full" style={{ backgroundColor: bgColors[entry.battlegroup] }} />
+                                BG{entry.battlegroup}
+                              </span>
+                            ) : (
+                              <span className="text-slate-600">Unassigned</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3 font-mono text-slate-400">{entry.player.championPrestige ?? "-"}</td>
+                          <td className="px-4 py-3">
+                            <span className={cn(
+                              "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-semibold",
+                              entry.status === "CHECKED_IN" ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300" :
+                              entry.status === "CONFIRMED" ? "border-sky-500/30 bg-sky-500/10 text-sky-300" :
+                              entry.status === "DROPPED" ? "border-red-500/30 bg-red-500/10 text-red-300" :
+                              "border-slate-700 bg-slate-900 text-slate-400"
+                            )}>
+                              {entry.status === "CHECKED_IN" ? <CheckCircle2 className="h-3.5 w-3.5" /> : <CircleDot className="h-3.5 w-3.5" />}
+                              {participantLabels[entry.status]}
+                            </span>
+                          </td>
+                          {canManageSelected && (
+                            <td className="px-4 py-3 text-right">
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                disabled={isPending}
+                                onClick={() => runAction(() => removeTournamentParticipant(entry.id))}
+                                className="h-8 w-8 text-slate-500 hover:bg-red-950/30 hover:text-red-300"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </Button>
+                            </td>
+                          )}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </Card>
+
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+                <Card className="border-slate-800/70 bg-slate-950/60 p-5">
+                  <Flag className="h-5 w-5 text-cyan-300" />
+                  <h3 className="mt-3 font-bold text-white">Registration Control</h3>
+                  <p className="mt-1 text-sm text-slate-500">Host alliance-only friendlies or community events that anyone with a CereBro profile can join.</p>
+                </Card>
+                <Card className="border-slate-800/70 bg-slate-950/60 p-5">
+                  <Users className="h-5 w-5 text-amber-300" />
+                  <h3 className="mt-3 font-bold text-white">Field Organization</h3>
+                  <p className="mt-1 text-sm text-slate-500">Seed players, keep battlegroup context visible, and identify unbalanced signup pools.</p>
+                </Card>
+                <Card className="border-slate-800/70 bg-slate-950/60 p-5">
+                  <Swords className="h-5 w-5 text-emerald-300" />
+                  <h3 className="mt-3 font-bold text-white">Bracket Ready</h3>
+                  <p className="mt-1 text-sm text-slate-500">Single elim, double elim, Swiss, Swiss top cut, round robin, and ladder are now first-class formats.</p>
+                </Card>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -69,6 +69,11 @@ export default function Header({ userButton, isInAlliance, hasPlayerProfile }: {
               Quest Planner
             </Link>
 
+            <Link href="/battlegrounds/tournaments" className="flex items-center gap-2 text-slate-300 hover:text-white transition-colors px-2 py-2">
+              <Trophy className="w-4 h-4" />
+              BG Tournaments
+            </Link>
+
             {isInAlliance ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -117,6 +122,7 @@ export default function Header({ userButton, isInAlliance, hasPlayerProfile }: {
                         <span>Season Stats</span>
                     </Link>
                   </DropdownMenuItem>
+
                 </DropdownMenuContent>
               </DropdownMenu>
             ) : (
@@ -207,6 +213,13 @@ export default function Header({ userButton, isInAlliance, hasPlayerProfile }: {
                                         Quest Planner
                                       </Link>
                                       <Link
+                                          href="/battlegrounds/tournaments"
+                                          className="flex items-center gap-2 text-lg font-medium text-slate-300 hover:text-white transition-colors"
+                                      >
+                                        <Trophy className="w-5 h-5" />
+                                        BG Tournaments
+                                      </Link>
+                                      <Link
                                           href="/war-videos"
                                           className="flex items-center gap-2 text-lg font-medium text-slate-300 hover:text-white transition-colors"
                                       >
@@ -261,7 +274,7 @@ export default function Header({ userButton, isInAlliance, hasPlayerProfile }: {
                             <Trophy className="w-5 h-5 text-yellow-500" />
                             Season Stats
                         </Link>
-                        
+
                         <div className="h-px bg-slate-800/50 my-1" />
                       </>
                     ) : (


### PR DESCRIPTION
## Summary
- Add Battlegrounds tournament schema, migrations, and organizer docs/context
- Add /battlegrounds/tournaments organizer UI and server actions
- Link BG Tournaments from desktop and mobile navigation

## Verification
- pnpm prisma:generate
- pnpm exec tsc --noEmit
- pnpm --filter web lint (passes with existing warnings)