### PR TITLE
Add battlegrounds tournament match operations

### DIFF
--- a/web/src/app/battlegrounds/tournaments/actions.test.ts
+++ b/web/src/app/battlegrounds/tournaments/actions.test.ts
@@ -3,6 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const prismaFake = vi.hoisted(() => ({
   battlegroundsTournament: {
     create: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  battlegroundsTournamentMatch: {
+    createMany: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
   },
 }));
 
@@ -27,7 +33,11 @@ vi.mock("@/lib/with-request-context", () => ({
 }));
 vi.mock("next/cache", () => cacheFake);
 
-import { createTournament } from "./actions";
+import {
+  createTournament,
+  generateTournamentMatches,
+  recordTournamentMatchResult,
+} from "./actions";
 
 function buildCreateTournamentForm(overrides: Record<string, string> = {}) {
   const formData = new FormData();
@@ -54,6 +64,8 @@ describe("battlegrounds tournament actions", () => {
     });
     permissionsFake.canPlanAllianceWar.mockReturnValue(true);
     prismaFake.battlegroundsTournament.create.mockResolvedValue({ id: "tournament_1" });
+    prismaFake.battlegroundsTournamentMatch.createMany.mockResolvedValue({ count: 2 });
+    prismaFake.battlegroundsTournamentMatch.update.mockResolvedValue({ id: "match_1" });
   });
 
   it("stores datetime-local values using the browser timezone offset", async () => {
@@ -63,6 +75,74 @@ describe("battlegrounds tournament actions", () => {
       data: expect.objectContaining({
         startsAt: new Date("2026-06-05T00:00:00.000Z"),
         checkInStartsAt: new Date("2026-06-04T23:30:00.000Z"),
+      }),
+    });
+  });
+
+  it("generates seeded high-low elimination matches for the first round", async () => {
+    prismaFake.battlegroundsTournament.findUnique.mockResolvedValue({
+      id: "tournament_1",
+      allianceId: "alliance_1",
+      createdById: "player_1",
+      format: "SINGLE_ELIMINATION",
+      participants: [
+        { id: "p1", seed: 1, createdAt: new Date("2026-01-01T00:00:00Z") },
+        { id: "p2", seed: 2, createdAt: new Date("2026-01-02T00:00:00Z") },
+        { id: "p3", seed: 3, createdAt: new Date("2026-01-03T00:00:00Z") },
+        { id: "p4", seed: 4, createdAt: new Date("2026-01-04T00:00:00Z") },
+      ],
+      matches: [],
+    });
+
+    await expect(generateTournamentMatches("tournament_1")).resolves.toEqual({ success: true });
+
+    expect(prismaFake.battlegroundsTournamentMatch.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          round: 1,
+          matchNumber: 1,
+          homeParticipantId: "p1",
+          awayParticipantId: "p4",
+          status: "READY",
+        }),
+        expect.objectContaining({
+          round: 1,
+          matchNumber: 2,
+          homeParticipantId: "p2",
+          awayParticipantId: "p3",
+          status: "READY",
+        }),
+      ],
+    });
+  });
+
+  it("records a final result and infers the winner from scores", async () => {
+    prismaFake.battlegroundsTournamentMatch.findUnique.mockResolvedValue({
+      id: "match_1",
+      homeParticipantId: "p1",
+      awayParticipantId: "p2",
+      tournament: {
+        id: "tournament_1",
+        allianceId: "alliance_1",
+        createdById: "player_1",
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("matchId", "match_1");
+    formData.set("homeScore", "3");
+    formData.set("awayScore", "2");
+    formData.set("status", "FINAL");
+
+    await expect(recordTournamentMatchResult(formData)).resolves.toEqual({ success: true });
+
+    expect(prismaFake.battlegroundsTournamentMatch.update).toHaveBeenCalledWith({
+      where: { id: "match_1" },
+      data: expect.objectContaining({
+        homeScore: 3,
+        awayScore: 2,
+        winnerParticipantId: "p1",
+        status: "FINAL",
       }),
     });
   });

--- a/web/src/app/battlegrounds/tournaments/actions.test.ts
+++ b/web/src/app/battlegrounds/tournaments/actions.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaFake = vi.hoisted(() => ({
+  battlegroundsTournament: {
+    create: vi.fn(),
+  },
+}));
+
+const authHelpersFake = vi.hoisted(() => ({
+  getUserPlayerWithAlliance: vi.fn(),
+}));
+
+const permissionsFake = vi.hoisted(() => ({
+  canPlanAllianceWar: vi.fn(),
+}));
+
+const cacheFake = vi.hoisted(() => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/prisma", () => ({ prisma: prismaFake }));
+vi.mock("@/lib/auth-helpers", () => authHelpersFake);
+vi.mock("@/lib/alliance-permissions", () => permissionsFake);
+vi.mock("@/lib/logger", () => ({ default: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() } }));
+vi.mock("@/lib/with-request-context", () => ({
+  withActionContext: (_name: string, fn: unknown) => fn,
+}));
+vi.mock("next/cache", () => cacheFake);
+
+import { createTournament } from "./actions";
+
+function buildCreateTournamentForm(overrides: Record<string, string> = {}) {
+  const formData = new FormData();
+  formData.set("name", overrides.name ?? "Friday BG Gauntlet");
+  formData.set("description", overrides.description ?? "Friendly bracket");
+  formData.set("scope", overrides.scope ?? "COMMUNITY");
+  formData.set("format", overrides.format ?? "SINGLE_ELIMINATION");
+  formData.set("startsAt", overrides.startsAt ?? "2026-06-04T20:00");
+  formData.set("startsAtTimezoneOffsetMinutes", overrides.startsAtTimezoneOffsetMinutes ?? "240");
+  formData.set("checkInStartsAt", overrides.checkInStartsAt ?? "2026-06-04T19:30");
+  formData.set("checkInStartsAtTimezoneOffsetMinutes", overrides.checkInStartsAtTimezoneOffsetMinutes ?? "240");
+  return formData;
+}
+
+describe("battlegrounds tournament actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authHelpersFake.getUserPlayerWithAlliance.mockResolvedValue({
+      id: "player_1",
+      allianceId: "alliance_1",
+      isBotAdmin: false,
+      isOfficer: true,
+      isPlanner: false,
+    });
+    permissionsFake.canPlanAllianceWar.mockReturnValue(true);
+    prismaFake.battlegroundsTournament.create.mockResolvedValue({ id: "tournament_1" });
+  });
+
+  it("stores datetime-local values using the browser timezone offset", async () => {
+    await expect(createTournament(buildCreateTournamentForm())).resolves.toEqual({ success: true });
+
+    expect(prismaFake.battlegroundsTournament.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        startsAt: new Date("2026-06-05T00:00:00.000Z"),
+        checkInStartsAt: new Date("2026-06-04T23:30:00.000Z"),
+      }),
+    });
+  });
+});

--- a/web/src/app/battlegrounds/tournaments/actions.ts
+++ b/web/src/app/battlegrounds/tournaments/actions.ts
@@ -58,11 +58,30 @@ function readTrimmedString(formData: FormData, key: string) {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function readOptionalDate(formData: FormData, key: string) {
+function readOptionalLocalDate(formData: FormData, key: string) {
   const value = readTrimmedString(formData, key);
   if (!value) return null;
 
-  const parsed = new Date(value);
+  const match = value.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/
+  );
+  if (!match) return undefined;
+
+  const offsetMinutes = Number(readTrimmedString(formData, `${key}TimezoneOffsetMinutes`));
+  if (!Number.isInteger(offsetMinutes)) return undefined;
+
+  const [, year, month, day, hour, minute, second = "0"] = match;
+  const parsed = new Date(
+    Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(minute),
+      Number(second)
+    ) + offsetMinutes * 60_000
+  );
+
   if (Number.isNaN(parsed.getTime())) return undefined;
   return parsed;
 }
@@ -87,8 +106,8 @@ export const createTournament = withActionContext(
     const player = await requireTournamentPlanner();
     const name = readTrimmedString(formData, "name");
     const description = readTrimmedString(formData, "description");
-    const startsAt = readOptionalDate(formData, "startsAt");
-    const checkInStartsAt = readOptionalDate(formData, "checkInStartsAt");
+    const startsAt = readOptionalLocalDate(formData, "startsAt");
+    const checkInStartsAt = readOptionalLocalDate(formData, "checkInStartsAt");
     const scope = parseScope(formData.get("scope"), !!player.allianceId);
 
     if (!name) {
@@ -96,7 +115,7 @@ export const createTournament = withActionContext(
     }
 
     if (startsAt === undefined || checkInStartsAt === undefined) {
-      return { success: false, error: "Use valid dates or leave date fields empty." };
+      return { success: false, error: "Use valid dates with a browser timezone or leave date fields empty." };
     }
 
     await prisma.battlegroundsTournament.create({

--- a/web/src/app/battlegrounds/tournaments/actions.ts
+++ b/web/src/app/battlegrounds/tournaments/actions.ts
@@ -2,6 +2,7 @@
 
 import {
   BattlegroundsTournamentFormat,
+  BattlegroundsMatchStatus,
   BattlegroundsTournamentScope,
   BattlegroundsTournamentStatus,
   TournamentParticipantStatus,
@@ -98,6 +99,222 @@ function parseParticipantStatus(value: FormDataEntryValue | null) {
   return Object.values(TournamentParticipantStatus).includes(value as TournamentParticipantStatus)
     ? value as TournamentParticipantStatus
     : TournamentParticipantStatus.CONFIRMED;
+}
+
+function readPositiveInteger(formData: FormData, key: string) {
+  const value = readTrimmedString(formData, key);
+  if (!value) return null;
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function readOptionalScore(formData: FormData, key: string) {
+  const value = readTrimmedString(formData, key);
+  if (!value) return null;
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}
+
+function parseMatchStatus(value: FormDataEntryValue | null) {
+  if (typeof value !== "string") return BattlegroundsMatchStatus.FINAL;
+  return Object.values(BattlegroundsMatchStatus).includes(value as BattlegroundsMatchStatus)
+    ? value as BattlegroundsMatchStatus
+    : BattlegroundsMatchStatus.FINAL;
+}
+
+type TournamentForMatches = Awaited<ReturnType<typeof loadManagedTournamentForMatches>>;
+
+async function loadManagedTournamentForMatches(
+  player: Awaited<ReturnType<typeof requireTournamentPlanner>>,
+  tournamentId: string
+) {
+  const tournament = await prisma.battlegroundsTournament.findUnique({
+    where: { id: tournamentId },
+    select: {
+      id: true,
+      allianceId: true,
+      createdById: true,
+      format: true,
+      participants: {
+        select: {
+          id: true,
+          seed: true,
+          createdAt: true,
+        },
+      },
+      matches: {
+        select: {
+          id: true,
+          round: true,
+          matchNumber: true,
+          status: true,
+          homeParticipantId: true,
+          awayParticipantId: true,
+          winnerParticipantId: true,
+          homeScore: true,
+          awayScore: true,
+        },
+        orderBy: [
+          { round: "asc" },
+          { matchNumber: "asc" },
+        ],
+      },
+    },
+  });
+
+  if (!tournament || !canManageTournament(player, tournament)) {
+    return null;
+  }
+
+  return tournament;
+}
+
+function sortedEntrants(tournament: NonNullable<TournamentForMatches>) {
+  return [...tournament.participants].sort((a, b) => {
+    const aSeed = a.seed ?? 9999;
+    const bSeed = b.seed ?? 9999;
+    if (aSeed !== bSeed) return aSeed - bSeed;
+    return a.createdAt.getTime() - b.createdAt.getTime();
+  });
+}
+
+function standingsOrder(tournament: NonNullable<TournamentForMatches>) {
+  const standings = new Map<string, { participantId: string; wins: number; losses: number; pointsFor: number; pointsAgainst: number; seed: number; createdAt: Date }>();
+
+  for (const entrant of tournament.participants) {
+    standings.set(entrant.id, {
+      participantId: entrant.id,
+      wins: 0,
+      losses: 0,
+      pointsFor: 0,
+      pointsAgainst: 0,
+      seed: entrant.seed ?? 9999,
+      createdAt: entrant.createdAt,
+    });
+  }
+
+  for (const match of tournament.matches) {
+    if (match.status !== BattlegroundsMatchStatus.FINAL || !match.homeParticipantId || !match.awayParticipantId) continue;
+
+    const home = standings.get(match.homeParticipantId);
+    const away = standings.get(match.awayParticipantId);
+    if (!home || !away) continue;
+
+    home.pointsFor += match.homeScore ?? 0;
+    home.pointsAgainst += match.awayScore ?? 0;
+    away.pointsFor += match.awayScore ?? 0;
+    away.pointsAgainst += match.homeScore ?? 0;
+
+    if (match.winnerParticipantId === home.participantId) {
+      home.wins += 1;
+      away.losses += 1;
+    } else if (match.winnerParticipantId === away.participantId) {
+      away.wins += 1;
+      home.losses += 1;
+    }
+  }
+
+  return [...standings.values()].sort((a, b) => {
+    if (b.wins !== a.wins) return b.wins - a.wins;
+    const aDiff = a.pointsFor - a.pointsAgainst;
+    const bDiff = b.pointsFor - b.pointsAgainst;
+    if (bDiff !== aDiff) return bDiff - aDiff;
+    if (a.seed !== b.seed) return a.seed - b.seed;
+    return a.createdAt.getTime() - b.createdAt.getTime();
+  });
+}
+
+function pairHighLow(participantIds: string[]) {
+  const pairs: Array<[string, string | null]> = [];
+  let left = 0;
+  let right = participantIds.length - 1;
+
+  while (left <= right) {
+    if (left === right) {
+      pairs.push([participantIds[left], null]);
+    } else {
+      pairs.push([participantIds[left], participantIds[right]]);
+    }
+    left += 1;
+    right -= 1;
+  }
+
+  return pairs;
+}
+
+function pairAdjacent(participantIds: string[]) {
+  const pairs: Array<[string, string | null]> = [];
+
+  for (let index = 0; index < participantIds.length; index += 2) {
+    pairs.push([participantIds[index], participantIds[index + 1] ?? null]);
+  }
+
+  return pairs;
+}
+
+function roundRobinPairs(participantIds: string[]) {
+  const pairs: Array<{ round: number; homeParticipantId: string; awayParticipantId: string | null }> = [];
+
+  for (let homeIndex = 0; homeIndex < participantIds.length; homeIndex += 1) {
+    for (let awayIndex = homeIndex + 1; awayIndex < participantIds.length; awayIndex += 1) {
+      pairs.push({
+        round: homeIndex + 1,
+        homeParticipantId: participantIds[homeIndex],
+        awayParticipantId: participantIds[awayIndex],
+      });
+    }
+  }
+
+  return pairs;
+}
+
+function nextRound(tournament: NonNullable<TournamentForMatches>) {
+  return tournament.matches.reduce((round, match) => Math.max(round, match.round), 0) + 1;
+}
+
+function buildGeneratedMatches(tournament: NonNullable<TournamentForMatches>) {
+  const seededIds = sortedEntrants(tournament).map((entrant) => entrant.id);
+  const rankedIds = standingsOrder(tournament).map((standing) => standing.participantId);
+
+  if (seededIds.length < 2) {
+    return { error: "Add at least two participants before generating matches." };
+  }
+
+  if (tournament.format === BattlegroundsTournamentFormat.ROUND_ROBIN) {
+    if (tournament.matches.length > 0) {
+      return { error: "Round robin schedule already exists. Add manual matches for adjustments." };
+    }
+
+    return {
+      matches: roundRobinPairs(seededIds).map((pair, index) => ({
+        tournamentId: tournament.id,
+        round: pair.round,
+        matchNumber: index + 1,
+        homeParticipantId: pair.homeParticipantId,
+        awayParticipantId: pair.awayParticipantId,
+        status: BattlegroundsMatchStatus.READY,
+      })),
+    };
+  }
+
+  const round = nextRound(tournament);
+  const basePairs = tournament.format === BattlegroundsTournamentFormat.SINGLE_ELIMINATION ||
+    tournament.format === BattlegroundsTournamentFormat.DOUBLE_ELIMINATION
+    ? pairHighLow(round === 1 ? seededIds : rankedIds)
+    : pairAdjacent(rankedIds);
+
+  return {
+    matches: basePairs.map(([homeParticipantId, awayParticipantId], index) => ({
+      tournamentId: tournament.id,
+      round,
+      matchNumber: index + 1,
+      homeParticipantId,
+      awayParticipantId,
+      status: BattlegroundsMatchStatus.READY,
+    })),
+  };
 }
 
 export const createTournament = withActionContext(
@@ -283,6 +500,187 @@ export const joinTournament = withActionContext(
     } catch {
       return { success: false, error: "You are already in this tournament." };
     }
+
+    revalidatePath(TOURNAMENTS_PATH);
+    return { success: true };
+  }
+);
+
+export const generateTournamentMatches = withActionContext(
+  "generateBattlegroundsTournamentMatches",
+  async (tournamentId: string): Promise<TournamentActionResult> => {
+    const player = await requireTournamentPlanner();
+    const tournament = await loadManagedTournamentForMatches(player, tournamentId);
+
+    if (!tournament) {
+      return { success: false, error: "Tournament not found." };
+    }
+
+    const generated = buildGeneratedMatches(tournament);
+    if ("error" in generated) {
+      return { success: false, error: generated.error ?? "Unable to generate matches." };
+    }
+
+    try {
+      await prisma.battlegroundsTournamentMatch.createMany({
+        data: generated.matches,
+      });
+    } catch {
+      return { success: false, error: "Matches already exist for that generated round." };
+    }
+
+    revalidatePath(TOURNAMENTS_PATH);
+    return { success: true };
+  }
+);
+
+export const createTournamentMatch = withActionContext(
+  "createBattlegroundsTournamentMatch",
+  async (formData: FormData): Promise<TournamentActionResult> => {
+    const player = await requireTournamentPlanner();
+    const tournamentId = readTrimmedString(formData, "tournamentId");
+    const round = readPositiveInteger(formData, "round");
+    const matchNumber = readPositiveInteger(formData, "matchNumber");
+    const homeParticipantId = readTrimmedString(formData, "homeParticipantId");
+    const awayParticipantId = readTrimmedString(formData, "awayParticipantId") || null;
+    const notes = readTrimmedString(formData, "notes");
+
+    if (!tournamentId || !homeParticipantId || round === null || matchNumber === null) {
+      return { success: false, error: "Choose a tournament, round, match number, and home player." };
+    }
+
+    if (round === undefined || matchNumber === undefined) {
+      return { success: false, error: "Round and match number must be positive whole numbers." };
+    }
+
+    if (awayParticipantId && awayParticipantId === homeParticipantId) {
+      return { success: false, error: "A player cannot face themselves." };
+    }
+
+    const tournament = await loadManagedTournamentForMatches(player, tournamentId);
+    if (!tournament) {
+      return { success: false, error: "Tournament not found." };
+    }
+
+    const participantIds = new Set(tournament.participants.map((participant) => participant.id));
+    if (!participantIds.has(homeParticipantId) || (awayParticipantId && !participantIds.has(awayParticipantId))) {
+      return { success: false, error: "Both match players must be in this tournament." };
+    }
+
+    try {
+      await prisma.battlegroundsTournamentMatch.create({
+        data: {
+          tournamentId,
+          round,
+          matchNumber,
+          homeParticipantId,
+          awayParticipantId,
+          status: BattlegroundsMatchStatus.READY,
+          notes: notes || null,
+        },
+      });
+    } catch {
+      return { success: false, error: "A match already exists with that round and match number." };
+    }
+
+    revalidatePath(TOURNAMENTS_PATH);
+    return { success: true };
+  }
+);
+
+export const recordTournamentMatchResult = withActionContext(
+  "recordBattlegroundsTournamentMatchResult",
+  async (formData: FormData): Promise<TournamentActionResult> => {
+    const player = await requireTournamentPlanner();
+    const matchId = readTrimmedString(formData, "matchId");
+    const homeScore = readOptionalScore(formData, "homeScore");
+    const awayScore = readOptionalScore(formData, "awayScore");
+    const requestedWinnerId = readTrimmedString(formData, "winnerParticipantId") || null;
+    const status = parseMatchStatus(formData.get("status"));
+    const notes = readTrimmedString(formData, "notes");
+
+    if (!matchId) {
+      return { success: false, error: "Choose a match to report." };
+    }
+
+    if (homeScore === undefined || awayScore === undefined) {
+      return { success: false, error: "Scores must be whole numbers or left empty." };
+    }
+
+    const match = await prisma.battlegroundsTournamentMatch.findUnique({
+      where: { id: matchId },
+      select: {
+        id: true,
+        homeParticipantId: true,
+        awayParticipantId: true,
+        tournament: {
+          select: {
+            id: true,
+            allianceId: true,
+            createdById: true,
+          },
+        },
+      },
+    });
+
+    if (!match || !canManageTournament(player, match.tournament)) {
+      return { success: false, error: "Match not found." };
+    }
+
+    let winnerParticipantId = requestedWinnerId;
+    if (!winnerParticipantId && homeScore !== null && awayScore !== null && homeScore !== awayScore) {
+      winnerParticipantId = homeScore > awayScore ? match.homeParticipantId : match.awayParticipantId;
+    }
+
+    const validWinnerIds = new Set([match.homeParticipantId, match.awayParticipantId].filter(Boolean));
+    if (winnerParticipantId && !validWinnerIds.has(winnerParticipantId)) {
+      return { success: false, error: "Winner must be one of the match players." };
+    }
+
+    if (status === BattlegroundsMatchStatus.FINAL && !winnerParticipantId) {
+      return { success: false, error: "Final matches need a winner." };
+    }
+
+    await prisma.battlegroundsTournamentMatch.update({
+      where: { id: matchId },
+      data: {
+        homeScore,
+        awayScore,
+        winnerParticipantId,
+        status,
+        notes: notes || null,
+      },
+    });
+
+    revalidatePath(TOURNAMENTS_PATH);
+    return { success: true };
+  }
+);
+
+export const deleteTournamentMatch = withActionContext(
+  "deleteBattlegroundsTournamentMatch",
+  async (matchId: string): Promise<TournamentActionResult> => {
+    const player = await requireTournamentPlanner();
+
+    const match = await prisma.battlegroundsTournamentMatch.findUnique({
+      where: { id: matchId },
+      select: {
+        tournament: {
+          select: {
+            allianceId: true,
+            createdById: true,
+          },
+        },
+      },
+    });
+
+    if (!match || !canManageTournament(player, match.tournament)) {
+      return { success: false, error: "Match not found." };
+    }
+
+    await prisma.battlegroundsTournamentMatch.delete({
+      where: { id: matchId },
+    });
 
     revalidatePath(TOURNAMENTS_PATH);
     return { success: true };

--- a/web/src/app/battlegrounds/tournaments/page.tsx
+++ b/web/src/app/battlegrounds/tournaments/page.tsx
@@ -85,6 +85,53 @@ export default async function BattlegroundsTournamentsPage() {
             { createdAt: "asc" },
           ],
         },
+        matches: {
+          include: {
+            homeParticipant: {
+              include: {
+                player: {
+                  select: {
+                    id: true,
+                    ingameName: true,
+                    battlegroup: true,
+                    championPrestige: true,
+                    avatar: true,
+                  },
+                },
+              },
+            },
+            awayParticipant: {
+              include: {
+                player: {
+                  select: {
+                    id: true,
+                    ingameName: true,
+                    battlegroup: true,
+                    championPrestige: true,
+                    avatar: true,
+                  },
+                },
+              },
+            },
+            winnerParticipant: {
+              include: {
+                player: {
+                  select: {
+                    id: true,
+                    ingameName: true,
+                    battlegroup: true,
+                    championPrestige: true,
+                    avatar: true,
+                  },
+                },
+              },
+            },
+          },
+          orderBy: [
+            { round: "asc" },
+            { matchNumber: "asc" },
+          ],
+        },
         _count: { select: { matches: true } },
       },
       orderBy: [
@@ -110,17 +157,28 @@ export default async function BattlegroundsTournamentsPage() {
     3: player.alliance?.battlegroup3Color || "#3b82f6",
   };
 
+  const serializeParticipant = (participant: typeof tournaments[number]["participants"][number]) => ({
+    ...participant,
+    checkedInAt: participant.checkedInAt?.toISOString() ?? null,
+    createdAt: participant.createdAt.toISOString(),
+    updatedAt: participant.updatedAt.toISOString(),
+  });
+
   const serializedTournaments = tournaments.map((tournament) => ({
     ...tournament,
     startsAt: tournament.startsAt?.toISOString() ?? null,
     checkInStartsAt: tournament.checkInStartsAt?.toISOString() ?? null,
     createdAt: tournament.createdAt.toISOString(),
     updatedAt: tournament.updatedAt.toISOString(),
-    participants: tournament.participants.map((participant) => ({
-      ...participant,
-      checkedInAt: participant.checkedInAt?.toISOString() ?? null,
-      createdAt: participant.createdAt.toISOString(),
-      updatedAt: participant.updatedAt.toISOString(),
+    participants: tournament.participants.map(serializeParticipant),
+    matches: tournament.matches.map((match) => ({
+      ...match,
+      scheduledAt: match.scheduledAt?.toISOString() ?? null,
+      createdAt: match.createdAt.toISOString(),
+      updatedAt: match.updatedAt.toISOString(),
+      homeParticipant: match.homeParticipant ? serializeParticipant(match.homeParticipant) : null,
+      awayParticipant: match.awayParticipant ? serializeParticipant(match.awayParticipant) : null,
+      winnerParticipant: match.winnerParticipant ? serializeParticipant(match.winnerParticipant) : null,
     })),
   }));
 

--- a/web/src/app/battlegrounds/tournaments/tournaments-client.tsx
+++ b/web/src/app/battlegrounds/tournaments/tournaments-client.tsx
@@ -112,6 +112,15 @@ const formatLabels: Record<BattlegroundsTournamentFormat, string> = {
   LADDER: "Ladder",
 };
 
+const formatDescriptions: Record<BattlegroundsTournamentFormat, string> = {
+  SINGLE_ELIMINATION: "Lose once and you are out. Fastest option for small one-night brackets.",
+  DOUBLE_ELIMINATION: "Players move to a lower bracket after one loss and are eliminated after the second loss.",
+  SWISS: "Everyone plays a fixed number of rounds against players with similar records. Best for ranking a larger field.",
+  SWISS_TOP_CUT: "Swiss rounds rank the field, then the top players advance to an elimination bracket.",
+  ROUND_ROBIN: "Every player faces every other player. Clear and fair, but match count grows quickly.",
+  LADDER: "Players climb by challenging nearby ranks. Best for longer-running flexible events.",
+};
+
 const scopeLabels: Record<BattlegroundsTournamentScope, string> = {
   COMMUNITY: "Community",
   ALLIANCE: "Alliance",
@@ -132,6 +141,16 @@ function formatDate(value: string | null) {
     hour: "2-digit",
     minute: "2-digit",
   }).format(new Date(value));
+}
+
+function appendTimezoneOffset(formData: FormData, key: string) {
+  const value = formData.get(key);
+  if (typeof value !== "string" || !value) return;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return;
+
+  formData.set(`${key}TimezoneOffsetMinutes`, String(date.getTimezoneOffset()));
 }
 
 function statusTone(status: BattlegroundsTournamentStatus) {
@@ -177,6 +196,7 @@ export function BattlegroundsTournamentsClient({
   const [isPending, startTransition] = useTransition();
   const [selectedTournamentId, setSelectedTournamentId] = useState(tournaments[0]?.id ?? null);
   const [message, setMessage] = useState<string | null>(null);
+  const [formFormat, setFormFormat] = useState<BattlegroundsTournamentFormat>("SINGLE_ELIMINATION");
   const selectedTournament = tournaments.find((tournament) => tournament.id === selectedTournamentId) ?? tournaments[0] ?? null;
   const manageableTournamentIdSet = useMemo(
     () => new Set(manageableTournamentIds),
@@ -301,7 +321,11 @@ export function BattlegroundsTournamentsClient({
                   </DialogHeader>
                   <form
                     className="space-y-4"
-                    action={(formData) => runAction(() => createTournament(formData))}
+                    action={(formData) => {
+                      appendTimezoneOffset(formData, "startsAt");
+                      appendTimezoneOffset(formData, "checkInStartsAt");
+                      runAction(() => createTournament(formData));
+                    }}
                   >
                     <div className="space-y-2">
                       <Label htmlFor="name">Name</Label>
@@ -321,7 +345,13 @@ export function BattlegroundsTournamentsClient({
                       </div>
                       <div className="space-y-2">
                         <Label htmlFor="format">Format</Label>
-                        <select id="format" name="format" className="h-9 w-full rounded-md border border-slate-800 bg-slate-900 px-3 text-sm text-slate-100">
+                        <select
+                          id="format"
+                          name="format"
+                          value={formFormat}
+                          onChange={(event) => setFormFormat(event.target.value as BattlegroundsTournamentFormat)}
+                          className="h-9 w-full rounded-md border border-slate-800 bg-slate-900 px-3 text-sm text-slate-100"
+                        >
                           <option value="SINGLE_ELIMINATION">Single Elimination</option>
                           <option value="DOUBLE_ELIMINATION">Double Elimination</option>
                           <option value="SWISS">Swiss</option>
@@ -329,17 +359,20 @@ export function BattlegroundsTournamentsClient({
                           <option value="ROUND_ROBIN">Round Robin</option>
                           <option value="LADDER">Ladder</option>
                         </select>
+                        <p className="text-xs leading-5 text-slate-500">{formatDescriptions[formFormat]}</p>
                       </div>
                     </div>
                     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                       <div className="space-y-2">
                         <Label htmlFor="startsAt">Start time</Label>
                         <Input id="startsAt" name="startsAt" type="datetime-local" className="border-slate-800 bg-slate-900" />
+                        <p className="text-xs leading-5 text-slate-500">Saved using your device timezone.</p>
                       </div>
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="checkInStartsAt">Check-in opens</Label>
                       <Input id="checkInStartsAt" name="checkInStartsAt" type="datetime-local" className="border-slate-800 bg-slate-900" />
+                      <p className="text-xs leading-5 text-slate-500">Entrants will see this converted to their local time.</p>
                     </div>
                     <Button disabled={isPending} className="w-full bg-cyan-500 text-slate-950 hover:bg-cyan-400">
                       <Plus className="h-4 w-4" />
@@ -416,6 +449,9 @@ export function BattlegroundsTournamentsClient({
                       {selectedTournament.description && (
                         <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">{selectedTournament.description}</p>
                       )}
+                      <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-500">
+                        {formatDescriptions[selectedTournament.format]}
+                      </p>
                     </div>
                     <div className="flex flex-col gap-2 sm:flex-row">
                     {canJoinSelected && (

--- a/web/src/app/battlegrounds/tournaments/tournaments-client.tsx
+++ b/web/src/app/battlegrounds/tournaments/tournaments-client.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import {
+  BattlegroundsMatchStatus,
   BattlegroundsTournamentFormat,
   BattlegroundsTournamentScope,
   BattlegroundsTournamentStatus,
@@ -45,7 +46,11 @@ import { cn } from "@/lib/utils";
 import {
   addTournamentParticipant,
   createTournament,
+  createTournamentMatch,
+  deleteTournamentMatch,
+  generateTournamentMatches,
   joinTournament,
+  recordTournamentMatchResult,
   removeTournamentParticipant,
   updateTournamentStatus,
   type TournamentActionResult,
@@ -79,6 +84,43 @@ export type TournamentSummary = {
     status: TournamentParticipantStatus;
     checkedInAt: string | null;
     player: TournamentMember;
+  }>;
+  matches: Array<{
+    id: string;
+    round: number;
+    matchNumber: number;
+    status: BattlegroundsMatchStatus;
+    homeParticipantId: string | null;
+    awayParticipantId: string | null;
+    winnerParticipantId: string | null;
+    homeScore: number | null;
+    awayScore: number | null;
+    scheduledAt: string | null;
+    notes: string | null;
+    homeParticipant: {
+      id: string;
+      seed: number | null;
+      battlegroup: number | null;
+      status: TournamentParticipantStatus;
+      checkedInAt: string | null;
+      player: TournamentMember;
+    } | null;
+    awayParticipant: {
+      id: string;
+      seed: number | null;
+      battlegroup: number | null;
+      status: TournamentParticipantStatus;
+      checkedInAt: string | null;
+      player: TournamentMember;
+    } | null;
+    winnerParticipant: {
+      id: string;
+      seed: number | null;
+      battlegroup: number | null;
+      status: TournamentParticipantStatus;
+      checkedInAt: string | null;
+      player: TournamentMember;
+    } | null;
   }>;
   _count: { matches: number };
 };
@@ -133,6 +175,30 @@ const participantLabels: Record<TournamentParticipantStatus, string> = {
   DROPPED: "Dropped",
 };
 
+const matchStatusLabels: Record<BattlegroundsMatchStatus, string> = {
+  PENDING: "Pending",
+  READY: "Ready",
+  PLAYING: "Playing",
+  REPORTED: "Reported",
+  DISPUTED: "Disputed",
+  FINAL: "Final",
+};
+
+function matchStatusTone(status: BattlegroundsMatchStatus) {
+  switch (status) {
+    case "FINAL":
+      return "border-emerald-500/30 bg-emerald-500/10 text-emerald-300";
+    case "DISPUTED":
+      return "border-red-500/30 bg-red-500/10 text-red-300";
+    case "REPORTED":
+      return "border-amber-500/30 bg-amber-500/10 text-amber-300";
+    case "PLAYING":
+      return "border-sky-500/30 bg-sky-500/10 text-sky-300";
+    default:
+      return "border-slate-700 bg-slate-900 text-slate-400";
+  }
+}
+
 function formatDate(value: string | null) {
   if (!value) return "Unscheduled";
   return new Intl.DateTimeFormat(undefined, {
@@ -179,6 +245,67 @@ function sortParticipants(tournament: TournamentSummary) {
     const bBg = b.battlegroup ?? 99;
     if (aBg !== bBg) return aBg - bBg;
     return a.player.ingameName.localeCompare(b.player.ingameName);
+  });
+}
+
+function groupMatchesByRound(tournament: TournamentSummary) {
+  const groups = new Map<number, TournamentSummary["matches"]>();
+
+  for (const match of tournament.matches) {
+    const roundMatches = groups.get(match.round) ?? [];
+    roundMatches.push(match);
+    groups.set(match.round, roundMatches);
+  }
+
+  return [...groups.entries()].sort(([a], [b]) => a - b);
+}
+
+function buildStandings(tournament: TournamentSummary) {
+  const standings = new Map<string, {
+    participant: TournamentSummary["participants"][number];
+    wins: number;
+    losses: number;
+    pointsFor: number;
+    pointsAgainst: number;
+  }>();
+
+  for (const participant of tournament.participants) {
+    standings.set(participant.id, {
+      participant,
+      wins: 0,
+      losses: 0,
+      pointsFor: 0,
+      pointsAgainst: 0,
+    });
+  }
+
+  for (const match of tournament.matches) {
+    if (match.status !== "FINAL" || !match.homeParticipantId || !match.awayParticipantId) continue;
+
+    const home = standings.get(match.homeParticipantId);
+    const away = standings.get(match.awayParticipantId);
+    if (!home || !away) continue;
+
+    home.pointsFor += match.homeScore ?? 0;
+    home.pointsAgainst += match.awayScore ?? 0;
+    away.pointsFor += match.awayScore ?? 0;
+    away.pointsAgainst += match.homeScore ?? 0;
+
+    if (match.winnerParticipantId === match.homeParticipantId) {
+      home.wins += 1;
+      away.losses += 1;
+    } else if (match.winnerParticipantId === match.awayParticipantId) {
+      away.wins += 1;
+      home.losses += 1;
+    }
+  }
+
+  return [...standings.values()].sort((a, b) => {
+    if (b.wins !== a.wins) return b.wins - a.wins;
+    const aDiff = a.pointsFor - a.pointsAgainst;
+    const bDiff = b.pointsFor - b.pointsAgainst;
+    if (bDiff !== aDiff) return bDiff - aDiff;
+    return sortParticipants({ ...tournament, participants: [a.participant, b.participant] })[0].id === a.participant.id ? -1 : 1;
   });
 }
 
@@ -242,6 +369,14 @@ export function BattlegroundsTournamentsClient({
     bg,
     count: participants.filter((entry) => entry.battlegroup === bg).length,
   }));
+  const standings = selectedTournament ? buildStandings(selectedTournament) : [];
+  const matchRounds = selectedTournament ? groupMatchesByRound(selectedTournament) : [];
+  const nextManualRound = selectedTournament
+    ? Math.max(1, ...selectedTournament.matches.map((match) => match.round))
+    : 1;
+  const nextManualMatchNumber = selectedTournament
+    ? selectedTournament.matches.filter((match) => match.round === nextManualRound).length + 1
+    : 1;
 
   return (
     <div className="space-y-6">
@@ -603,6 +738,181 @@ export function BattlegroundsTournamentsClient({
                       ))}
                     </tbody>
                   </table>
+                </div>
+
+                <div className="grid grid-cols-1 gap-0 border-t border-slate-800 xl:grid-cols-[320px_1fr]">
+                  <div className="border-b border-slate-800 p-5 xl:border-b-0 xl:border-r">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <h3 className="font-bold text-white">Standings</h3>
+                        <p className="text-xs text-slate-500">Ranked by wins, point differential, then seed.</p>
+                      </div>
+                      <Badge variant="outline" className="border-slate-700 text-slate-400">
+                        {selectedTournament.matches.filter((match) => match.status === "FINAL").length} final
+                      </Badge>
+                    </div>
+                    <div className="mt-4 space-y-2">
+                      {standings.length === 0 && (
+                        <p className="rounded-lg border border-dashed border-slate-800 p-4 text-sm text-slate-500">
+                          Add participants and matches to build standings.
+                        </p>
+                      )}
+                      {standings.map((standing, index) => (
+                        <div key={standing.participant.id} className="flex items-center justify-between gap-3 rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-2">
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-semibold text-slate-200">
+                              #{index + 1} {standing.participant.player.ingameName}
+                            </p>
+                            <p className="text-xs text-slate-500">
+                              {standing.participant.battlegroup ? `BG${standing.participant.battlegroup}` : "Community"} · seed {standing.participant.seed ?? "-"}
+                            </p>
+                          </div>
+                          <div className="text-right font-mono text-sm text-slate-300">
+                            <p>{standing.wins}-{standing.losses}</p>
+                            <p className="text-xs text-slate-500">
+                              {standing.pointsFor - standing.pointsAgainst >= 0 ? "+" : ""}{standing.pointsFor - standing.pointsAgainst}
+                            </p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+
+                  <div className="min-w-0 p-5">
+                    <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                      <div>
+                        <h3 className="font-bold text-white">Matches</h3>
+                        <p className="text-sm text-slate-500">
+                          Generate format-aware rounds, add manual pairings, and record results.
+                        </p>
+                      </div>
+                      {canManageSelected && (
+                        <Button
+                          disabled={isPending || participants.length < 2}
+                          onClick={() => runAction(() => generateTournamentMatches(selectedTournament.id))}
+                          className="bg-emerald-500 text-slate-950 hover:bg-emerald-400"
+                        >
+                          <Swords className="h-4 w-4" />
+                          Generate next matches
+                        </Button>
+                      )}
+                    </div>
+
+                    {canManageSelected && (
+                      <form
+                        className="mt-4 grid grid-cols-1 gap-3 rounded-lg border border-slate-800 bg-slate-950/70 p-3 lg:grid-cols-[80px_80px_1fr_1fr_auto]"
+                        action={(formData) => runAction(() => createTournamentMatch(formData))}
+                      >
+                        <input type="hidden" name="tournamentId" value={selectedTournament.id} />
+                        <Input name="round" inputMode="numeric" defaultValue={nextManualRound} className="border-slate-800 bg-slate-900" />
+                        <Input name="matchNumber" inputMode="numeric" defaultValue={nextManualMatchNumber} className="border-slate-800 bg-slate-900" />
+                        <select name="homeParticipantId" className="h-9 rounded-md border border-slate-800 bg-slate-900 px-3 text-sm text-slate-100">
+                          <option value="">Home player...</option>
+                          {participants.map((entry) => (
+                            <option key={entry.id} value={entry.id}>{entry.player.ingameName}</option>
+                          ))}
+                        </select>
+                        <select name="awayParticipantId" className="h-9 rounded-md border border-slate-800 bg-slate-900 px-3 text-sm text-slate-100">
+                          <option value="">Away player / bye...</option>
+                          {participants.map((entry) => (
+                            <option key={entry.id} value={entry.id}>{entry.player.ingameName}</option>
+                          ))}
+                        </select>
+                        <Button disabled={isPending} className="bg-slate-100 text-slate-950 hover:bg-white">
+                          <Plus className="h-4 w-4" />
+                          Add match
+                        </Button>
+                      </form>
+                    )}
+
+                    <div className="mt-4 space-y-5">
+                      {matchRounds.length === 0 && (
+                        <div className="rounded-lg border border-dashed border-slate-800 p-6 text-center">
+                          <Swords className="mx-auto h-8 w-8 text-slate-700" />
+                          <p className="mt-2 font-semibold text-slate-300">No matches yet</p>
+                          <p className="mt-1 text-sm text-slate-500">
+                            Generate the first round once the field is ready, or add pairings manually.
+                          </p>
+                        </div>
+                      )}
+
+                      {matchRounds.map(([round, matches]) => (
+                        <div key={round} className="space-y-3">
+                          <div className="flex items-center gap-2">
+                            <h4 className="text-sm font-bold uppercase tracking-widest text-slate-400">Round {round}</h4>
+                            <div className="h-px flex-1 bg-slate-800" />
+                          </div>
+                          {matches.map((match) => (
+                            <div key={match.id} className="rounded-lg border border-slate-800 bg-slate-900/50 p-3">
+                              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                                <div className="min-w-0">
+                                  <div className="flex flex-wrap items-center gap-2">
+                                    <Badge variant="outline" className="border-slate-700 text-slate-400">
+                                      Match {match.matchNumber}
+                                    </Badge>
+                                    <Badge variant="outline" className={cn(matchStatusTone(match.status))}>
+                                      {matchStatusLabels[match.status]}
+                                    </Badge>
+                                  </div>
+                                  <div className="mt-3 grid grid-cols-1 gap-2 text-sm sm:grid-cols-[1fr_auto_1fr] sm:items-center">
+                                    <p className={cn("font-semibold", match.winnerParticipantId === match.homeParticipantId ? "text-emerald-300" : "text-slate-200")}>
+                                      {match.homeParticipant?.player.ingameName ?? "TBD"}
+                                    </p>
+                                    <p className="text-center font-mono text-slate-500">
+                                      {match.homeScore ?? "-"} : {match.awayScore ?? "-"}
+                                    </p>
+                                    <p className={cn("font-semibold sm:text-right", match.winnerParticipantId === match.awayParticipantId ? "text-emerald-300" : "text-slate-200")}>
+                                      {match.awayParticipant?.player.ingameName ?? "Bye"}
+                                    </p>
+                                  </div>
+                                  {match.notes && <p className="mt-2 text-xs text-slate-500">{match.notes}</p>}
+                                </div>
+
+                                {canManageSelected && (
+                                  <Button
+                                    size="icon"
+                                    variant="ghost"
+                                    disabled={isPending}
+                                    onClick={() => runAction(() => deleteTournamentMatch(match.id))}
+                                    className="h-8 w-8 shrink-0 text-slate-500 hover:bg-red-950/30 hover:text-red-300"
+                                  >
+                                    <Trash2 className="h-4 w-4" />
+                                  </Button>
+                                )}
+                              </div>
+
+                              {canManageSelected && (
+                                <form
+                                  className="mt-3 grid grid-cols-1 gap-2 border-t border-slate-800 pt-3 lg:grid-cols-[80px_80px_1fr_150px_auto]"
+                                  action={(formData) => runAction(() => recordTournamentMatchResult(formData))}
+                                >
+                                  <input type="hidden" name="matchId" value={match.id} />
+                                  <Input name="homeScore" inputMode="numeric" defaultValue={match.homeScore ?? ""} placeholder="Home" className="border-slate-800 bg-slate-950" />
+                                  <Input name="awayScore" inputMode="numeric" defaultValue={match.awayScore ?? ""} placeholder="Away" className="border-slate-800 bg-slate-950" />
+                                  <select name="winnerParticipantId" defaultValue={match.winnerParticipantId ?? ""} className="h-9 rounded-md border border-slate-800 bg-slate-950 px-3 text-sm text-slate-100">
+                                    <option value="">Auto / no winner</option>
+                                    {match.homeParticipant && <option value={match.homeParticipant.id}>{match.homeParticipant.player.ingameName}</option>}
+                                    {match.awayParticipant && <option value={match.awayParticipant.id}>{match.awayParticipant.player.ingameName}</option>}
+                                  </select>
+                                  <select name="status" defaultValue={match.status === "PENDING" || match.status === "READY" ? "FINAL" : match.status} className="h-9 rounded-md border border-slate-800 bg-slate-950 px-3 text-sm text-slate-100">
+                                    <option value="FINAL">Final</option>
+                                    <option value="REPORTED">Reported</option>
+                                    <option value="DISPUTED">Disputed</option>
+                                    <option value="PLAYING">Playing</option>
+                                    <option value="READY">Ready</option>
+                                  </select>
+                                  <Button disabled={isPending} className="bg-cyan-500 text-slate-950 hover:bg-cyan-400">
+                                    <CheckCircle2 className="h-4 w-4" />
+                                    Save result
+                                  </Button>
+                                </form>
+                              )}
+                            </div>
+                          ))}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
                 </div>
               </Card>
 


### PR DESCRIPTION
## Summary
- Add format-aware match generation for Battlegrounds tournaments
- Add manual match creation, result recording, winner selection, dispute/final states, and match deletion
- Load and render match rounds with standings computed from final results
- Extend battlegrounds action tests for seeded generation and result recording

## Verification
- pnpm exec vitest --run web/src/app/battlegrounds/tournaments/actions.test.ts
- pnpm exec tsc --noEmit
- pnpm --filter web exec tsc --noEmit
- pnpm --filter web lint (passes with existing warnings)

## Note
This branch is stacked on eature/bg-tournaments / PR #66 because it builds on the tournament schema and page introduced there.